### PR TITLE
Forbedret datovelger ved default null

### DIFF
--- a/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.tsx
+++ b/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.tsx
@@ -59,9 +59,7 @@ class ArbeidstidSteg extends React.Component<Context, State> {
                     <Datovelger
                         className="arbeidstidsteg__datovelger"
                         velgDato={this.velgStartDato}
-                        dato={moment(
-                            this.props.avtale.startDato || moment().valueOf()
-                        )}
+                        dato={moment(this.props.avtale.startDato)}
                         settRiktigFormatert={this.settStartDatoRiktigFormatert}
                         inputRiktigFormatert={
                             this.state.startDatoRiktigFormatert

--- a/src/AvtaleSide/ArbeidstidSteg/Datovelger/datovelger.tsx
+++ b/src/AvtaleSide/ArbeidstidSteg/Datovelger/datovelger.tsx
@@ -7,7 +7,7 @@ import DatoInputfelt from './dato-inputfelt';
 import { Normaltekst } from 'nav-frontend-typografi';
 
 import './datovelger.less';
-import { momentAsISO } from './moment-utils';
+import { momentAsISO, momentIDag } from './moment-utils';
 
 interface OwnProps {
     velgDato: (dato: Moment) => void;
@@ -44,6 +44,10 @@ class Datovelger extends React.Component<Props, State> {
     }
 
     toggleKalender() {
+        if (!this.props.dato.isValid()) {
+            this.props.velgDato(momentIDag());
+        }
+
         this.setState({
             ...this.state,
             visKalender: !this.state.visKalender,


### PR DESCRIPTION
Datovelgeren hadde en bug som gjorde at om man klikket på kalender visningen uten at det var satt en standard dato, så kræsjet alt. Fikset ved å sette dagens dato hvis ingen dato ved kalender knappetrykk.
Gjør også så vi unngår ukonsistens mellom hva datofeltet viser og hva som ligger i state (slik som i tidligere løsning).