### PR TITLE
TAG-588-Justere-ikon-i-del-avtale-link

### DIFF
--- a/src/AvtaleSide/AvtaleSide.less
+++ b/src/AvtaleSide/AvtaleSide.less
@@ -35,9 +35,16 @@
 
         &__lenkedeling {
             margin-bottom: 0.5rem;
+
             svg {
                 display: inline-block;
+                margin-right: 0.5rem;
             }
+        }
+
+        &__lenkedelingLenke {
+            display: flex;
+            align-items: center;
         }
 
         &__container {

--- a/src/AvtaleSide/DesktopAvtaleSide/DesktopAvtaleSide.tsx
+++ b/src/AvtaleSide/DesktopAvtaleSide/DesktopAvtaleSide.tsx
@@ -20,8 +20,13 @@ const DesktopAvtaleSide: React.FunctionComponent<Props> = props => {
             <div className="avtaleside__desktop">
                 {props.rolle === 'VEILEDER' && (
                     <div className="avtaleside__lenkedeling">
-                        <Lenke onClick={() => setOpen(true)} href="#">
-                            Del lenke til avtalen <ShareIkon />
+                        <Lenke
+                            className="avtaleside__lenkedelingLenke"
+                            onClick={() => setOpen(true)}
+                            href="#"
+                        >
+                            <ShareIkon />
+                            Del lenke til avtalen
                         </Lenke>
                     </div>
                 )}


### PR DESCRIPTION
<img width="485" alt="Screenshot 2019-06-03 at 16 22 50" src="https://user-images.githubusercontent.com/20104610/58809253-db1f2080-861b-11e9-8c44-1ef03703027d.png">

Sentrert inneholdet i Lenke-komponenten slik at tekst og ikon er allignet. Ser muligens ikke slik ut pga. underline på tekst, men ser penere ut enn før.