### PR TITLE
TAG-58 Lagt til fremover og bakover støtte for både dato og bool

### DIFF
--- a/src/AvtaleContext.tsx
+++ b/src/AvtaleContext.tsx
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import * as React from 'react';
 import { withRouter } from 'react-router-dom';
-import { Avtale, Maal, Oppgave, Godkjenninger } from './AvtaleSide/avtale';
+import { Avtale, Maal, Oppgave } from './AvtaleSide/avtale';
 import Varsel from './komponenter/Varsel/Varsel';
 import RestService from './services/rest-service';
 import ApiError from './api-error';

--- a/src/AvtaleContext.tsx
+++ b/src/AvtaleContext.tsx
@@ -172,14 +172,12 @@ export class TempAvtaleProvider extends React.Component<any, State> {
 
         const godkjenningerBool = this.konverterGodkjentTilBool(avtale);
         const avtaleBool = { ...avtale, ...godkjenningerBool };
-
+        debugger;
         this.setState({ avtale: avtaleBool });
     }
 
     konverterGodkjentTilBool = (avtale: Avtale) => {
-        let godkjenninger: Godkjenninger = {
-            status: avtale.status,
-            erLaast: avtale.erLaast,
+        let godkjenninger = {
             godkjentAvArbeidsgiver: false,
             godkjentAvDeltaker: false,
             godkjentAvVeileder: false,

--- a/src/AvtaleContext.tsx
+++ b/src/AvtaleContext.tsx
@@ -176,7 +176,7 @@ export class TempAvtaleProvider extends React.Component<any, State> {
         this.setState({ avtale: avtaleBool });
     }
 
-    konverterGodkjentTilBool = (avtale: any) => {
+    konverterGodkjentTilBool = (avtale: Avtale) => {
         let godkjenninger: Godkjenninger = {
             status: avtale.status,
             erLaast: avtale.erLaast,

--- a/src/AvtaleContext.tsx
+++ b/src/AvtaleContext.tsx
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import * as React from 'react';
 import { withRouter } from 'react-router-dom';
-import { Avtale, Maal, Oppgave } from './AvtaleSide/avtale';
+import { Avtale, Maal, Oppgave, Godkjenninger } from './AvtaleSide/avtale';
 import Varsel from './komponenter/Varsel/Varsel';
 import RestService from './services/rest-service';
 import ApiError from './api-error';
@@ -169,8 +169,41 @@ export class TempAvtaleProvider extends React.Component<any, State> {
 
     async hentAvtale(avtaleId: string) {
         const avtale = await RestService.hentAvtale(avtaleId);
-        this.setState({ avtale });
+
+        const godkjenningerBool = this.konverterGodkjentTilBool(avtale);
+        const avtaleBool = { ...avtale, ...godkjenningerBool };
+
+        this.setState({ avtale: avtaleBool });
     }
+
+    konverterGodkjentTilBool = (avtale: any) => {
+        let godkjenninger: Godkjenninger = {
+            status: avtale.status,
+            erLaast: avtale.erLaast,
+            godkjentAvArbeidsgiver: false,
+            godkjentAvDeltaker: false,
+            godkjentAvVeileder: false,
+        };
+        const {
+            godkjentAvArbeidsgiver,
+            godkjentAvDeltaker,
+            godkjentAvVeileder,
+        } = avtale;
+
+        if (
+            godkjentAvArbeidsgiver &&
+            typeof godkjentAvArbeidsgiver !== 'boolean'
+        ) {
+            godkjenninger.godkjentAvArbeidsgiver = true;
+        }
+        if (godkjentAvDeltaker && typeof godkjentAvDeltaker !== 'boolean') {
+            godkjenninger.godkjentAvDeltaker = true;
+        }
+        if (godkjentAvVeileder && typeof godkjentAvVeileder !== 'boolean') {
+            godkjenninger.godkjentAvVeileder = true;
+        }
+        return godkjenninger;
+    };
 
     async hentRolle(avtaleId: string) {
         const rolle = await RestService.hentRolle(avtaleId);

--- a/src/AvtaleContext.tsx
+++ b/src/AvtaleContext.tsx
@@ -172,7 +172,7 @@ export class TempAvtaleProvider extends React.Component<any, State> {
 
         const godkjenningerBool = this.konverterGodkjentTilBool(avtale);
         const avtaleBool = { ...avtale, ...godkjenningerBool };
-        debugger;
+
         this.setState({ avtale: avtaleBool });
     }
 


### PR DESCRIPTION
Lagt til kode som forsikrer at både dato og boolean er støttet, slik at frontend vil fungere uavhengig av hva som kommer fra backend, og dermed vil være kompatibel både før og etter godkjenning endringen i backend.