### PR TITLE
TAG-445 Stotte for ulike typer steg for arbeidstrening og for lonnstilskudd

### DIFF
--- a/src/AvtaleContext.tsx
+++ b/src/AvtaleContext.tsx
@@ -47,6 +47,7 @@ export const tomAvtale: Avtale = {
     status: '',
     kanAvbrytes: true,
     avbrutt: false,
+    tiltakstype: 'ARBEIDSTRENING',
     godkjentPaaVegneAv: false,
     godkjentPaVegneGrunn: {
         ikkeBankId: false,
@@ -230,7 +231,10 @@ export class TempAvtaleProvider extends React.Component<any, State> {
 
     async lagreAvtale() {
         const nyAvtale = await RestService.lagreAvtale(this.state.avtale);
-        this.setState({ avtale: nyAvtale, ulagredeEndringer: false });
+        this.setState({
+            avtale: { ...this.state.avtale, ...nyAvtale },
+            ulagredeEndringer: false,
+        });
     }
 
     lagreMaal(maalTilLagring: Maal) {
@@ -259,8 +263,7 @@ export class TempAvtaleProvider extends React.Component<any, State> {
 
         const godkjenningerBool = this.konverterGodkjentTilBool(avtale);
         const avtaleBool = { ...avtale, ...godkjenningerBool };
-
-        this.setState({ avtale: avtaleBool });
+        this.setState({ avtale: { ...this.state.avtale, ...avtaleBool } });
     }
 
     konverterGodkjentTilBool = (avtale: Avtale) => ({

--- a/src/AvtaleSide/AvtaleSide.spec.tsx
+++ b/src/AvtaleSide/AvtaleSide.spec.tsx
@@ -1,9 +1,8 @@
-
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
 import AvtaleSide from './AvtaleSide';
 
 test('Test that <AvtaleSide> renders correctly', () => {
-    const wrapper = shallow(<AvtaleSide/>);
+    const wrapper = shallow(<AvtaleSide />);
     expect(wrapper).toHaveLength(1);
 });

--- a/src/AvtaleSide/AvtaleSide.spec.tsx
+++ b/src/AvtaleSide/AvtaleSide.spec.tsx
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import AvtaleSide from './AvtaleSide';
 
-test('Test that <AvtaleSide> renders correctly', () => {
+test('Test at <AvtaleSide> rendres', () => {
     const wrapper = shallow(<AvtaleSide />);
     expect(wrapper).toHaveLength(1);
 });

--- a/src/AvtaleSide/AvtaleSide.tsx
+++ b/src/AvtaleSide/AvtaleSide.tsx
@@ -1,16 +1,15 @@
+import { Context, medContext, Rolle } from '@/AvtaleContext';
+import Banner from '@/komponenter/Banner/Banner';
+import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
+import VarselKomponent from '@/komponenter/Varsel/VarselKomponent';
+import { ApiError } from '@/types/errors';
+import BEMHelper from '@/utils/bem';
+import hentAvtaleSteg from '@/utils/stegUtils';
 import moment from 'moment';
 import AlertStripe from 'nav-frontend-alertstriper';
 import * as React from 'react';
 import { FunctionComponent, ReactNode, useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router';
-import { ApiError } from '@/types/errors';
-import { Context, medContext, Rolle } from '@/AvtaleContext';
-import Banner from '@/komponenter/Banner/Banner';
-import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
-import VarselKomponent from '@/komponenter/Varsel/VarselKomponent';
-import BEMHelper from '@/utils/bem';
-import ArbeidsoppgaverSteg from './ArbeidsoppgaverSteg/ArbeidsoppgaverSteg';
-import ArbeidstidSteg from './ArbeidstidSteg/ArbeidstidSteg';
 import AvtaleFetcher from './AvtaleFetcher';
 import './AvtaleSide.less';
 import DesktopAvtaleSide from './DesktopAvtaleSide/DesktopAvtaleSide';
@@ -19,10 +18,7 @@ import ArbeidsgiverInstruks from './GodkjenningSteg/Oppsummering/instruks/Arbeid
 import DeltakerInstruks from './GodkjenningSteg/Oppsummering/instruks/DeltakerInstruks';
 import VeilederInstruks from './GodkjenningSteg/Oppsummering/instruks/VeilederInstruks';
 import Oppsummering from './GodkjenningSteg/Oppsummering/oppsummering/Oppsummering';
-import KontaktinfoSteg from './KontaktInformasjonSteg/KontaktinfoSteg';
-import MaalSteg from './MaalSteg/MaalSteg';
 import MobilAvtaleSide from './MobilAvtaleSide/MobilAvtaleSide';
-import OppfolgingTilretteleggingSteg from './OppfolgingOgTilretteleggingSteg/OppfolgingOgTilretteleggingSteg';
 import TilbakeTilOversiktLenke from './TilbakeTilOversiktLenke/TilbakeTilOversiktLenke';
 
 interface MatchProps {
@@ -52,38 +48,7 @@ const AvtaleSide: FunctionComponent<Props> = props => {
         return () => window.removeEventListener('resize', handleWindowSize);
     });
 
-    const avtaleSteg: StegInfo[] = [
-        {
-            komponent: <KontaktinfoSteg {...props} />,
-            label: 'Kontaktinformasjon',
-            id: 'kontaktinformasjon',
-        },
-        {
-            komponent: <MaalSteg {...props} />,
-            label: 'Mål',
-            id: 'maal',
-        },
-        {
-            komponent: <ArbeidsoppgaverSteg {...props} />,
-            label: 'Arbeidsoppgaver',
-            id: 'arbeidsoppgaver',
-        },
-        {
-            komponent: <ArbeidstidSteg />,
-            label: 'Arbeidstid',
-            id: 'arbeidstid',
-        },
-        {
-            komponent: <OppfolgingTilretteleggingSteg />,
-            label: 'Oppfølging og tilrettelegging',
-            id: 'oppfolging',
-        },
-        {
-            komponent: <GodkjenningSteg />,
-            label: 'Godkjenning',
-            id: 'godkjenning',
-        },
-    ];
+    const avtaleSteg: StegInfo[] = hentAvtaleSteg[props.avtale.tiltakstype];
 
     const erDesktop = windowSize > 767;
     const aktivtSteg = avtaleSteg.find(

--- a/src/AvtaleSide/BeregningTilskudd/BeregningTilskudd.spec.tsx
+++ b/src/AvtaleSide/BeregningTilskudd/BeregningTilskudd.spec.tsx
@@ -1,0 +1,14 @@
+import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
+import { shallow } from 'enzyme';
+import React from 'react';
+import BeregningTilskudd from './BeregningTilskudd';
+
+test('Test that <GodkjenningSteg> renders correctly', () => {
+    const wrapper = shallow(<BeregningTilskudd />);
+    expect(wrapper).toHaveLength(1);
+});
+
+test('should render innholdsboks', () => {
+    const wrapper = shallow(<BeregningTilskudd />);
+    expect(wrapper.find(Innholdsboks)).toHaveLength(1);
+});

--- a/src/AvtaleSide/BeregningTilskudd/BeregningTilskudd.spec.tsx
+++ b/src/AvtaleSide/BeregningTilskudd/BeregningTilskudd.spec.tsx
@@ -3,12 +3,12 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import BeregningTilskudd from './BeregningTilskudd';
 
-test('Test that <GodkjenningSteg> renders correctly', () => {
+test('Test at <BeregningTilskudd> rendres', () => {
     const wrapper = shallow(<BeregningTilskudd />);
     expect(wrapper).toHaveLength(1);
 });
 
-test('should render innholdsboks', () => {
+test('Skal rendre Innholdsboks', () => {
     const wrapper = shallow(<BeregningTilskudd />);
     expect(wrapper.find(Innholdsboks)).toHaveLength(1);
 });

--- a/src/AvtaleSide/BeregningTilskudd/BeregningTilskudd.tsx
+++ b/src/AvtaleSide/BeregningTilskudd/BeregningTilskudd.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Innholdsboks from '../../komponenter/Innholdsboks/Innholdsboks';
+
+const BeregningTilskudd = () => {
+    return <Innholdsboks utfyller="veileder_og_arbeidsgiver"></Innholdsboks>;
+};
+
+export default BeregningTilskudd;

--- a/src/AvtaleSide/GodkjenningSteg/GodkjenningSteg.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/GodkjenningSteg.tsx
@@ -1,12 +1,15 @@
-import * as React from 'react';
 import { Context, medContext } from '@/AvtaleContext';
+import * as React from 'react';
 import Godkjenning from './Godkjenning';
 import GodkjenningStatus from './GodkjenningStatus/GodkjenningStatus';
-import Oppsummering from './Oppsummering/oppsummering/Oppsummering';
 
-const GodkjenningSteg = (props: Context) => (
+type Props = {
+    oppsummering: JSX.Element;
+};
+
+const GodkjenningSteg: React.FunctionComponent<Props & Context> = props => (
     <>
-        <Oppsummering avtale={props.avtale} rolle={props.rolle} />
+        {props.oppsummering}
         <Godkjenning
             avtale={props.avtale}
             rolle={props.rolle}

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/BeregningTilskuddOppsummering/BeregningTilskuddOppsummering.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/BeregningTilskuddOppsummering/BeregningTilskuddOppsummering.tsx
@@ -1,0 +1,15 @@
+import React, { FunctionComponent } from 'react';
+import SjekkOmVerdiEksisterer from '../SjekkOmVerdiEksisterer/SjekkOmVerdiEksisterer';
+import Stegoppsummering from '../Stegoppsummering/Stegoppsummering';
+
+interface Props {}
+
+const BeregningTilskuddOppsummering: FunctionComponent<Props> = () => (
+    <Stegoppsummering tittel="Beregning av tilskudd">
+        <div>
+            <SjekkOmVerdiEksisterer verdi={''} clsName="beregningTilskudd" />
+        </div>
+    </Stegoppsummering>
+);
+
+export default BeregningTilskuddOppsummering;

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/BeregningTilskuddOppsummering/BeregningtilskuddOppsummering.spec.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/BeregningTilskuddOppsummering/BeregningtilskuddOppsummering.spec.tsx
@@ -4,7 +4,7 @@ import SjekkOmVerdiEksisterer from '../SjekkOmVerdiEksisterer/SjekkOmVerdiEksist
 import Stegoppsummering from '../Stegoppsummering/Stegoppsummering';
 import BeregningTilskuddOppsummering from './BeregningTilskuddOppsummering';
 
-test('Test that <GodkjenningSteg> renders correctly', () => {
+test('Test at <BeregningTilskuddOppsummering> rendres', () => {
     const wrapper = shallow(<BeregningTilskuddOppsummering />);
     expect(wrapper).toHaveLength(1);
 });

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/BeregningTilskuddOppsummering/BeregningtilskuddOppsummering.spec.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/BeregningTilskuddOppsummering/BeregningtilskuddOppsummering.spec.tsx
@@ -1,0 +1,17 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import SjekkOmVerdiEksisterer from '../SjekkOmVerdiEksisterer/SjekkOmVerdiEksisterer';
+import Stegoppsummering from '../Stegoppsummering/Stegoppsummering';
+import BeregningTilskuddOppsummering from './BeregningTilskuddOppsummering';
+
+test('Test that <GodkjenningSteg> renders correctly', () => {
+    const wrapper = shallow(<BeregningTilskuddOppsummering />);
+    expect(wrapper).toHaveLength(1);
+});
+
+test('Skal rendre Stegoppsummering og SjekkOmVerdiEksisterer', () => {
+    const wrapper = shallow(<BeregningTilskuddOppsummering />);
+    expect(
+        wrapper.find(Stegoppsummering) && wrapper.find(SjekkOmVerdiEksisterer)
+    ).toHaveLength(1);
+});

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/LonnstilskuddOppsummering/LonnstilskuddOppsummering.spec.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/LonnstilskuddOppsummering/LonnstilskuddOppsummering.spec.tsx
@@ -1,0 +1,12 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import SjekkOmVerdiEksisterer from '../SjekkOmVerdiEksisterer/SjekkOmVerdiEksisterer';
+import Stegoppsummering from '../Stegoppsummering/Stegoppsummering';
+import LonnstilskuddOppsummering from './LonnstilskuddOppsummering';
+
+test('Skal rendre Stegoppsummering og SjekkOmVerdiEksisterer', () => {
+    const wrapper = shallow(<LonnstilskuddOppsummering />);
+    expect(
+        wrapper.find(Stegoppsummering) && wrapper.find(SjekkOmVerdiEksisterer)
+    ).toHaveLength(1);
+});

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/LonnstilskuddOppsummering/LonnstilskuddOppsummering.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/LonnstilskuddOppsummering/LonnstilskuddOppsummering.tsx
@@ -1,0 +1,15 @@
+import React, { FunctionComponent } from 'react';
+import SjekkOmVerdiEksisterer from '../SjekkOmVerdiEksisterer/SjekkOmVerdiEksisterer';
+import Stegoppsummering from '../Stegoppsummering/Stegoppsummering';
+
+interface Props {}
+
+const LonnstilskuddOppsummering: FunctionComponent<Props> = () => (
+    <Stegoppsummering tittel="Lønnstilskudd og varighet">
+        <div>
+            <SjekkOmVerdiEksisterer verdi={''} clsName="lonnstilskudd" />
+        </div>
+    </Stegoppsummering>
+);
+
+export default LonnstilskuddOppsummering;

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/OppsummeringLonnstilskudd/OppsummeringLonnstilskudd.spec.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/OppsummeringLonnstilskudd/OppsummeringLonnstilskudd.spec.tsx
@@ -13,7 +13,7 @@ const wrapper = shallow(
     shallow(<OppsummeringLonnstilskudd avtale={avtaleMock} />).get(0)
 );
 
-test('Skal rendre', () => {
+test('Skal rendre Innholdsboks', () => {
     expect(wrapper.dive().find(Innholdsboks)).toHaveLength(1);
 });
 

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/OppsummeringLonnstilskudd/OppsummeringLonnstilskudd.spec.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/OppsummeringLonnstilskudd/OppsummeringLonnstilskudd.spec.tsx
@@ -1,0 +1,35 @@
+import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
+import avtaleMock from '@/mocking/avtale-mock';
+import { shallow } from 'enzyme';
+import React from 'react';
+import Avtaleparter from '../Avtaleparter/Avtaleparter';
+import BeregningTilskuddOppsummering from '../BeregningTilskuddOppsummering/BeregningTilskuddOppsummering';
+import LonnstilskuddOppsummering from '../LonnstilskuddOppsummering/LonnstilskuddOppsummering';
+import OppfolgingOppsummering from '../oppfølging/OppfolgingOppsummering';
+import StillingsOppsummering from '../StillingsOppsummering/StillingsOppsummering';
+import OppsummeringLonnstilskudd from './OppsummeringLonnstilskudd';
+
+const wrapper = shallow(
+    shallow(<OppsummeringLonnstilskudd avtale={avtaleMock} />).get(0)
+);
+
+test('Skal rendre', () => {
+    expect(wrapper.dive().find(Innholdsboks)).toHaveLength(1);
+});
+
+// Oppsummeringskomponenter
+test('Skal rendre <Avtaleparter>', () => {
+    expect(wrapper.dive().find(Avtaleparter)).toHaveLength(1);
+});
+test('Skal rendre <StillingsOppsummering>', () => {
+    expect(wrapper.dive().find(StillingsOppsummering)).toHaveLength(1);
+});
+test('Skal rendre <LonnstilskuddOppsummering>', () => {
+    expect(wrapper.dive().find(LonnstilskuddOppsummering)).toHaveLength(1);
+});
+test('Skal rendre <OppfolgingOppsummering>', () => {
+    expect(wrapper.dive().find(OppfolgingOppsummering)).toHaveLength(1);
+});
+test('Skal rendre <BeregningTilskuddOppsummering>', () => {
+    expect(wrapper.dive().find(BeregningTilskuddOppsummering)).toHaveLength(1);
+});

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/OppsummeringLonnstilskudd/OppsummeringLonnstilskudd.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/OppsummeringLonnstilskudd/OppsummeringLonnstilskudd.tsx
@@ -1,29 +1,25 @@
-import { ReactComponent as PrinterSvg } from '@/assets/ikoner/printer2.svg';
-import { medContext, Rolle } from '@/AvtaleContext';
+import PrinterSvg from '@/assets/ikoner/PrinterSvg';
+import { medContext } from '@/AvtaleContext';
+import OppfolgingOppsummering from '@/AvtaleSide/GodkjenningSteg/Oppsummering/oppfølging/OppfolgingOppsummering';
 import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
 import { Avtale } from '@/types/avtale';
 import { Knapp } from 'nav-frontend-knapper';
 import { Systemtittel } from 'nav-frontend-typografi';
-import * as React from 'react';
-import { FunctionComponent } from 'react';
+import React, { FunctionComponent } from 'react';
 import Avtaleparter from '../Avtaleparter/Avtaleparter';
-import MaalOppsummering from '../maalOppsummering/MaalOppsummering';
-import OppfolgingOppsummering from '../oppfølging/OppfolgingOppsummering';
-import OppgaverOppsummering from '../oppgaveOppsummering/OppgaverOppsummering';
-import Tilrettelegging from '../tilrettelegging/Tilrettelegging';
-import VarighetOppsummering from '../varighet/VarighetOppsummering';
-import './Oppsummering.less';
+import BeregningTilskuddOppsummering from '../BeregningTilskuddOppsummering/BeregningTilskuddOppsummering';
+import LonnstilskuddOppsummering from '../LonnstilskuddOppsummering/LonnstilskuddOppsummering';
+import StillingsOppsummering from '../StillingsOppsummering/StillingsOppsummering';
 
 interface Props {
     avtale: Avtale;
-    rolle: Rolle;
 }
 
 const printAvtale = () => {
     window.print();
 };
 
-const Oppsummering: FunctionComponent<Props> = props => (
+const OppsummeringLonnstilskudd: FunctionComponent<Props> = props => (
     <Innholdsboks>
         <div className="oppsummering__header">
             <Systemtittel className="oppsummering__tittel">
@@ -46,12 +42,11 @@ const Oppsummering: FunctionComponent<Props> = props => (
         </div>
 
         <Avtaleparter {...props.avtale} />
-        <MaalOppsummering {...props.avtale} />
-        <OppgaverOppsummering {...props.avtale} />
-        <VarighetOppsummering {...props.avtale} />
+        <StillingsOppsummering />
+        <LonnstilskuddOppsummering />
         <OppfolgingOppsummering {...props.avtale} />
-        <Tilrettelegging {...props.avtale} />
+        <BeregningTilskuddOppsummering />
     </Innholdsboks>
 );
 
-export default medContext(Oppsummering);
+export default medContext(OppsummeringLonnstilskudd);

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/StillingsOppsummering/StillingsOppsummering.spec.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/StillingsOppsummering/StillingsOppsummering.spec.tsx
@@ -4,7 +4,7 @@ import SjekkOmVerdiEksisterer from '../SjekkOmVerdiEksisterer/SjekkOmVerdiEksist
 import Stegoppsummering from '../Stegoppsummering/Stegoppsummering';
 import StillingsOppsummering from './StillingsOppsummering';
 
-test('Test that <GodkjenningSteg> renders correctly', () => {
+test('Test at <StillingsOppsummering> rendres', () => {
     const wrapper = shallow(<StillingsOppsummering />);
     expect(wrapper).toHaveLength(1);
 });

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/StillingsOppsummering/StillingsOppsummering.spec.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/StillingsOppsummering/StillingsOppsummering.spec.tsx
@@ -1,0 +1,17 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import SjekkOmVerdiEksisterer from '../SjekkOmVerdiEksisterer/SjekkOmVerdiEksisterer';
+import Stegoppsummering from '../Stegoppsummering/Stegoppsummering';
+import StillingsOppsummering from './StillingsOppsummering';
+
+test('Test that <GodkjenningSteg> renders correctly', () => {
+    const wrapper = shallow(<StillingsOppsummering />);
+    expect(wrapper).toHaveLength(1);
+});
+
+test('Skal rendre Stegoppsummering og SjekkOmVerdiEksisterer', () => {
+    const wrapper = shallow(<StillingsOppsummering />);
+    expect(
+        wrapper.find(Stegoppsummering) && wrapper.find(SjekkOmVerdiEksisterer)
+    ).toHaveLength(1);
+});

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/StillingsOppsummering/StillingsOppsummering.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/StillingsOppsummering/StillingsOppsummering.tsx
@@ -1,0 +1,15 @@
+import React, { FunctionComponent } from 'react';
+import SjekkOmVerdiEksisterer from '../SjekkOmVerdiEksisterer/SjekkOmVerdiEksisterer';
+import Stegoppsummering from '../Stegoppsummering/Stegoppsummering';
+
+interface Props {}
+
+const StillingsOppsummering: FunctionComponent<Props> = () => (
+    <Stegoppsummering tittel="Stilling">
+        <div>
+            <SjekkOmVerdiEksisterer verdi={''} clsName="stilling" />
+        </div>
+    </Stegoppsummering>
+);
+
+export default StillingsOppsummering;

--- a/src/AvtaleSide/KontaktInformasjonSteg/KontaktinfoSteg.tsx
+++ b/src/AvtaleSide/KontaktInformasjonSteg/KontaktinfoSteg.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
 import { Context, medContext } from '@/AvtaleContext';
 import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
 import LagreKnapp from '@/komponenter/LagreKnapp/LagreKnapp';
+import * as React from 'react';
 import ArbeidsgiverinfoDel from './ArbeidsgiverinfoDel/ArbeidsgiverinfoDel';
 import DeltakerinfoDel from './DeltakerinfoDel/DeltakerinfoDel';
-import VeilederinfoDel from './VeilederinfoDel/VeilederinfoDel';
 import './KontaktinfoSteg.less';
+import VeilederinfoDel from './VeilederinfoDel/VeilederinfoDel';
 
 const KontaktinfoSteg = (props: Context) => (
     <Innholdsboks>

--- a/src/AvtaleSide/LonnstilskuddVarighet/LonnstilskuddVarighet.spec.tsx
+++ b/src/AvtaleSide/LonnstilskuddVarighet/LonnstilskuddVarighet.spec.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import LonnstilskuddVarighet from './LonnstilskuddVarighet';
 
-test('Test that <LonnstilskuddVarighet> renders correctly', () => {
+test('Test at <LonnstilskuddVarighet> rendres', () => {
     const wrapper = shallow(<LonnstilskuddVarighet />);
     expect(wrapper).toHaveLength(1);
 });

--- a/src/AvtaleSide/LonnstilskuddVarighet/LonnstilskuddVarighet.spec.tsx
+++ b/src/AvtaleSide/LonnstilskuddVarighet/LonnstilskuddVarighet.spec.tsx
@@ -1,0 +1,14 @@
+import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
+import { shallow } from 'enzyme';
+import React from 'react';
+import LonnstilskuddVarighet from './LonnstilskuddVarighet';
+
+test('Test that <LonnstilskuddVarighet> renders correctly', () => {
+    const wrapper = shallow(<LonnstilskuddVarighet />);
+    expect(wrapper).toHaveLength(1);
+});
+
+test('should render innholdsboks', () => {
+    const wrapper = shallow(<LonnstilskuddVarighet />);
+    expect(wrapper.find(Innholdsboks)).toHaveLength(1);
+});

--- a/src/AvtaleSide/LonnstilskuddVarighet/LonnstilskuddVarighet.tsx
+++ b/src/AvtaleSide/LonnstilskuddVarighet/LonnstilskuddVarighet.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Innholdsboks from '../../komponenter/Innholdsboks/Innholdsboks';
+
+const LonnstilskuddVarighet = () => {
+    return <Innholdsboks utfyller="veileder_og_arbeidsgiver"></Innholdsboks>;
+};
+
+export default LonnstilskuddVarighet;

--- a/src/AvtaleSide/Stegmeny/Stegmeny.tsx
+++ b/src/AvtaleSide/Stegmeny/Stegmeny.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
 import { Context, medContext } from '@/AvtaleContext';
 import { pathTilStegIAvtale } from '@/paths';
+import * as React from 'react';
 import { StegInfo } from '../AvtaleSide';
 import './Stegmeny.less';
 import StegmenyLenke from './StegmenyLenke/StegmenyLenke';

--- a/src/AvtaleSide/StillingSteg/StillingSteg.spec.tsx
+++ b/src/AvtaleSide/StillingSteg/StillingSteg.spec.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import StillingSteg from './StillingSteg';
 
-test('Test that <StillingSteg> renders correctly', () => {
+test('Test ar <StillingSteg> rendres', () => {
     const wrapper = shallow(<StillingSteg />);
     expect(wrapper).toHaveLength(1);
 });

--- a/src/AvtaleSide/StillingSteg/StillingSteg.spec.tsx
+++ b/src/AvtaleSide/StillingSteg/StillingSteg.spec.tsx
@@ -1,0 +1,14 @@
+import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
+import { shallow } from 'enzyme';
+import React from 'react';
+import StillingSteg from './StillingSteg';
+
+test('Test that <StillingSteg> renders correctly', () => {
+    const wrapper = shallow(<StillingSteg />);
+    expect(wrapper).toHaveLength(1);
+});
+
+test('should render innholdsboks', () => {
+    const wrapper = shallow(<StillingSteg />);
+    expect(wrapper.find(Innholdsboks)).toHaveLength(1);
+});

--- a/src/AvtaleSide/StillingSteg/StillingSteg.tsx
+++ b/src/AvtaleSide/StillingSteg/StillingSteg.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Innholdsboks from '../../komponenter/Innholdsboks/Innholdsboks';
+
+const StillingSteg = () => {
+    return <Innholdsboks utfyller="veileder_og_arbeidsgiver"></Innholdsboks>;
+};
+
+export default StillingSteg;

--- a/src/mocking/avtale-mock.ts
+++ b/src/mocking/avtale-mock.ts
@@ -69,6 +69,7 @@ const avtaleMock: Avtale = {
     arbeidsgiverFornavn: 'Arbeidsgiver',
     arbeidsgiverEtternavn: 'Arbeidsgiversen',
     arbeidsgiverTlf: '77777777',
+    tiltakstype: 'ARBEIDSTRENING',
 
     maal: maalListe,
     oppgaver: oppgaveListe,

--- a/src/types/avtale.ts
+++ b/src/types/avtale.ts
@@ -23,6 +23,7 @@ export interface AvtaleMetadata {
     id: string;
     opprettetTidspunkt: string;
     versjon: string;
+    tiltakstype: TiltaksType;
 }
 
 export interface Deltakerinfo {

--- a/src/utils/stegUtils.spec.tsx
+++ b/src/utils/stegUtils.spec.tsx
@@ -1,0 +1,12 @@
+import hentAvtaleSteg from './stegUtils';
+
+test('test riktig antall steg for arbeidstrening', () => {
+    const avtaleSteg = hentAvtaleSteg.ARBEIDSTRENING;
+    expect(avtaleSteg).toHaveLength(6);
+});
+
+test('test riktig antall steg for lønnstilskudd', () => {
+    const avtaleStegLtsMidlertidig = hentAvtaleSteg.MIDLERTIDIG_LONNSTILSKUDD;
+    const avtaleStegLtsVarig = hentAvtaleSteg.VARIG_LONNSTILSKUDD;
+    expect(avtaleStegLtsMidlertidig && avtaleStegLtsVarig).toHaveLength(6);
+});

--- a/src/utils/stegUtils.tsx
+++ b/src/utils/stegUtils.tsx
@@ -1,0 +1,89 @@
+import ArbeidsoppgaverSteg from '@/AvtaleSide/ArbeidsoppgaverSteg/ArbeidsoppgaverSteg';
+import ArbeidstidSteg from '@/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg';
+import { StegInfo } from '@/AvtaleSide/AvtaleSide';
+import BeregningTilskudd from '@/AvtaleSide/BeregningTilskudd/BeregningTilskudd';
+import GodkjenningSteg from '@/AvtaleSide/GodkjenningSteg/GodkjenningSteg';
+import Oppsummering from '@/AvtaleSide/GodkjenningSteg/Oppsummering/oppsummering/Oppsummering';
+import OppsummeringLonnstilskudd from '@/AvtaleSide/GodkjenningSteg/Oppsummering/OppsummeringLonnstilskudd/OppsummeringLonnstilskudd';
+import KontaktinfoSteg from '@/AvtaleSide/KontaktInformasjonSteg/KontaktinfoSteg';
+import LonnstilskuddVarighet from '@/AvtaleSide/LonnstilskuddVarighet/LonnstilskuddVarighet';
+import MaalSteg from '@/AvtaleSide/MaalSteg/MaalSteg';
+import OppfolgingTilretteleggingSteg from '@/AvtaleSide/OppfolgingOgTilretteleggingSteg/OppfolgingOgTilretteleggingSteg';
+import StillingSteg from '@/AvtaleSide/StillingSteg/StillingSteg';
+import React from 'react';
+
+const arbeidstreningSteg: StegInfo[] = [
+    {
+        komponent: <KontaktinfoSteg />,
+        label: 'Kontaktinformasjon',
+        id: 'kontaktinformasjon',
+    },
+    {
+        komponent: <MaalSteg />,
+        label: 'Mål',
+        id: 'maal',
+    },
+    {
+        komponent: <ArbeidsoppgaverSteg />,
+        label: 'Arbeidsoppgaver',
+        id: 'arbeidsoppgaver',
+    },
+    {
+        komponent: <ArbeidstidSteg />,
+        label: 'Arbeidstid',
+        id: 'arbeidstid',
+    },
+    {
+        komponent: <OppfolgingTilretteleggingSteg />,
+        label: 'Oppfølging og tilrettelegging',
+        id: 'oppfolging',
+    },
+    {
+        komponent: <GodkjenningSteg oppsummering={<Oppsummering />} />,
+        label: 'Godkjenning',
+        id: 'godkjenning',
+    },
+];
+
+const lonnstilskuddSteg: StegInfo[] = [
+    {
+        komponent: <KontaktinfoSteg />,
+        label: 'Kontaktinformasjon',
+        id: 'kontaktinformasjon',
+    },
+    {
+        komponent: <StillingSteg />,
+        label: 'Stilling',
+        id: 'stilling',
+    },
+    {
+        komponent: <LonnstilskuddVarighet />,
+        label: 'Lønnstilskudd og varighet',
+        id: 'lonnstilskuddvarighet',
+    },
+    {
+        komponent: <OppfolgingTilretteleggingSteg />,
+        label: 'Oppfølging og tilrettelegging',
+        id: 'oppfolging',
+    },
+    {
+        komponent: <BeregningTilskudd />,
+        label: 'Beregning av tilskudd',
+        id: 'beregningtilskudd',
+    },
+    {
+        komponent: (
+            <GodkjenningSteg oppsummering={<OppsummeringLonnstilskudd />} />
+        ),
+        label: 'Godkjenning',
+        id: 'godkjenning',
+    },
+];
+
+const hentAvtaleSteg = {
+    ARBEIDSTRENING: arbeidstreningSteg,
+    VARIG_LONNSTILSKUDD: lonnstilskuddSteg,
+    MIDLERTIDIG_LONNSTILSKUDD: lonnstilskuddSteg,
+};
+
+export default hentAvtaleSteg;


### PR DESCRIPTION
Lagt til nye lønnstilskudd spesfikke steg. Skilt ut listen over steg i egen komponent som nå holder på både arbeidstrening og lønnstilskudd steg. arbeidstrening er lagt inn som default verdi dersom man dette ikke er definert i avtalen fra backend (tomAvtale).