### PR TITLE
TAG-872 Endrer til sluttdato og stillingsprosent

### DIFF
--- a/src/AvtaleContext.tsx
+++ b/src/AvtaleContext.tsx
@@ -35,7 +35,7 @@ export const tomAvtale: Avtale = {
 
     startDato: moment().valueOf(),
     sluttDato: moment().valueOf(),
-    arbeidstreningStillingprosent: 0,
+    stillingprosent: 0,
 
     maal: [],
     oppgaver: [],

--- a/src/AvtaleContext.tsx
+++ b/src/AvtaleContext.tsx
@@ -34,7 +34,7 @@ export const tomAvtale: Avtale = {
     tilrettelegging: '',
 
     startDato: moment().valueOf(),
-    arbeidstreningLengde: 1,
+    sluttDato: moment().valueOf(),
     arbeidstreningStillingprosent: 0,
 
     maal: [],
@@ -110,7 +110,7 @@ export interface Context {
 
 export type Rolle = 'DELTAKER' | 'ARBEIDSGIVER' | 'VEILEDER' | 'INGEN_ROLLE';
 
-const AvtaleContext = React.createContext<Context>({} as Context);
+export const AvtaleContext = React.createContext<Context>({} as Context);
 
 export const AvtaleConsumer = AvtaleContext.Consumer;
 

--- a/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.less
+++ b/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.less
@@ -3,14 +3,11 @@
         margin-bottom: 1.5rem;
     }
 
-    &__startdato-label {
-        margin-bottom: 0.25rem;
-    }
-
     &__datovelger {
-        width: 9rem;
+        width: 10rem;
         margin-bottom: 2rem;
     }
+
     &__lagre-knapp {
         margin-top: 1rem;
     }

--- a/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.spec.tsx
+++ b/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.spec.tsx
@@ -1,9 +1,15 @@
-
 import React from 'react';
 import { shallow } from 'enzyme';
 import ArbeidstidSteg from './ArbeidstidSteg';
+import avtaleMock from '@/mocking/avtale-mock';
 
 test('Test that <ArbeidstidSteg> renders correctly', () => {
-    const wrapper = shallow(<ArbeidstidSteg/>);
+    const wrapper = shallow(
+        <ArbeidstidSteg
+            avtale={avtaleMock}
+            settAvtaleVerdi={() => {}}
+            lagreAvtale={() => Promise.resolve()}
+        />
+    );
     expect(wrapper).toHaveLength(1);
 });

--- a/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.tsx
+++ b/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.tsx
@@ -1,19 +1,20 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import { FunctionComponent, useContext, useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import LagreKnapp from '@/komponenter/LagreKnapp/LagreKnapp';
 import Datovelger from './Datovelger/Datovelger';
 import moment, { Moment } from 'moment';
 import { Normaltekst, Systemtittel } from 'nav-frontend-typografi';
-import { AvtaleContext } from '@/AvtaleContext';
 import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
 import StillingsprosentInput from './StillingsprosentInput/StillingsprosentInput';
 import InfoBoks from './InfoBoks/InfoBoks';
 import './ArbeidstidSteg.less';
 import BEMHelper from '@/utils/bem';
+import { Arbeidstid, Avtale } from '@/types/avtale';
+import { medContext } from '@/AvtaleContext';
+import { InputStegProps } from '@/AvtaleSide/input-steg-props';
 
-const ArbeidstidSteg: FunctionComponent<{}> = props => {
-    const avtaleContext = useContext(AvtaleContext);
+const ArbeidstidSteg: FunctionComponent<InputStegProps<Arbeidstid>> = props => {
     const [startDatoRiktigFormatert, setStartDatoRiktigFormatert] = useState<
         boolean
     >(true);
@@ -23,7 +24,7 @@ const ArbeidstidSteg: FunctionComponent<{}> = props => {
 
     const velgStartDato = (dato: Moment) => {
         setStartDatoRiktigFormatert(true);
-        avtaleContext.settAvtaleVerdi(
+        props.settAvtaleVerdi(
             'startDato',
             dato.toISOString(true).split('+')[0]
         );
@@ -31,17 +32,14 @@ const ArbeidstidSteg: FunctionComponent<{}> = props => {
 
     const velgSluttDato = (dato: Moment) => {
         setSluttDatoRiktigFormatert(true);
-        avtaleContext.settAvtaleVerdi(
+        props.settAvtaleVerdi(
             'sluttDato',
             dato.toISOString(true).split('+')[0]
         );
     };
 
     const timerIUka = Number(
-        (
-            (37.5 * avtaleContext.avtale.arbeidstreningStillingprosent) /
-            100
-        ).toFixed(2)
+        ((37.5 * props.avtale.arbeidstreningStillingprosent) / 100).toFixed(2)
     );
 
     const dagerIUka = Number(((timerIUka / 37.5) * 5).toFixed(2));
@@ -57,7 +55,7 @@ const ArbeidstidSteg: FunctionComponent<{}> = props => {
             <Datovelger
                 className={cls.element('datovelger')}
                 velgDato={velgStartDato}
-                dato={moment(avtaleContext.avtale.startDato)}
+                dato={moment(props.avtale.startDato)}
                 settRiktigFormatert={() => setStartDatoRiktigFormatert(true)}
                 inputRiktigFormatert={startDatoRiktigFormatert}
             />
@@ -65,15 +63,15 @@ const ArbeidstidSteg: FunctionComponent<{}> = props => {
             <Datovelger
                 className={cls.element('datovelger')}
                 velgDato={velgSluttDato}
-                dato={moment(avtaleContext.avtale.sluttDato)}
+                dato={moment(props.avtale.sluttDato)}
                 settRiktigFormatert={() => setSluttDatoRiktigFormatert(true)}
                 inputRiktigFormatert={sluttDatoRiktigFormatert}
             />
             <StillingsprosentInput
                 label="Hvilken stillingsprosent skal deltakeren ha?"
-                verdi={avtaleContext.avtale.arbeidstreningStillingprosent}
+                verdi={props.avtale.arbeidstreningStillingprosent}
                 settVerdi={_.partial(
-                    avtaleContext.settAvtaleVerdi,
+                    props.settAvtaleVerdi,
                     'arbeidstreningStillingprosent'
                 )}
             />
@@ -82,11 +80,11 @@ const ArbeidstidSteg: FunctionComponent<{}> = props => {
             <LagreKnapp
                 className={cls.element('lagre-knapp')}
                 label={'Lagre'}
-                lagre={avtaleContext.lagreAvtale}
+                lagre={props.lagreAvtale}
                 suksessmelding={'Avtale lagret'}
             />
         </Innholdsboks>
     );
 };
 
-export default ArbeidstidSteg;
+export default medContext(ArbeidstidSteg);

--- a/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.tsx
+++ b/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.tsx
@@ -39,7 +39,7 @@ const ArbeidstidSteg: FunctionComponent<InputStegProps<Arbeidstid>> = props => {
     };
 
     const timerIUka = Number(
-        ((37.5 * props.avtale.arbeidstreningStillingprosent) / 100).toFixed(2)
+        ((37.5 * props.avtale.stillingprosent) / 100).toFixed(2)
     );
 
     const dagerIUka = Number(((timerIUka / 37.5) * 5).toFixed(2));
@@ -69,11 +69,8 @@ const ArbeidstidSteg: FunctionComponent<InputStegProps<Arbeidstid>> = props => {
             />
             <StillingsprosentInput
                 label="Hvilken stillingsprosent skal deltakeren ha?"
-                verdi={props.avtale.arbeidstreningStillingprosent}
-                settVerdi={_.partial(
-                    props.settAvtaleVerdi,
-                    'arbeidstreningStillingprosent'
-                )}
+                verdi={props.avtale.stillingprosent}
+                settVerdi={_.partial(props.settAvtaleVerdi, 'stillingprosent')}
             />
             <InfoBoks timerIUka={timerIUka} dagerIUka={dagerIUka} />
 

--- a/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.tsx
+++ b/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.tsx
@@ -1,110 +1,92 @@
 import * as _ from 'lodash';
 import * as React from 'react';
+import { FunctionComponent, useContext, useState } from 'react';
 import LagreKnapp from '@/komponenter/LagreKnapp/LagreKnapp';
 import Datovelger from './Datovelger/Datovelger';
 import moment, { Moment } from 'moment';
 import { Normaltekst, Systemtittel } from 'nav-frontend-typografi';
-import { Context, medContext } from '@/AvtaleContext';
+import { AvtaleContext } from '@/AvtaleContext';
 import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
-import Ukevelger from './Ukevelger/Ukevelger';
 import StillingsprosentInput from './StillingsprosentInput/StillingsprosentInput';
 import InfoBoks from './InfoBoks/InfoBoks';
 import './ArbeidstidSteg.less';
-import { SkjemaelementFeil } from 'nav-frontend-skjema/lib/skjemaelement-feilmelding';
+import BEMHelper from '@/utils/bem';
 
-interface State {
-    startDatoRiktigFormatert: boolean;
-    stillingsprosentFeil?: SkjemaelementFeil;
-    arbTreningLengdeFeil?: SkjemaelementFeil;
-}
+const ArbeidstidSteg: FunctionComponent<{}> = props => {
+    const avtaleContext = useContext(AvtaleContext);
+    const [startDatoRiktigFormatert, setStartDatoRiktigFormatert] = useState<
+        boolean
+    >(true);
+    const [sluttDatoRiktigFormatert, setSluttDatoRiktigFormatert] = useState<
+        boolean
+    >(true);
 
-class ArbeidstidSteg extends React.Component<Context, State> {
-    state: State = {
-        startDatoRiktigFormatert: true,
-        stillingsprosentFeil: undefined,
-        arbTreningLengdeFeil: undefined,
-    };
-
-    velgStartDato = (dato: Moment) => {
-        this.setState({
-            startDatoRiktigFormatert: true,
-        });
-        this.props.settAvtaleVerdi(
+    const velgStartDato = (dato: Moment) => {
+        setStartDatoRiktigFormatert(true);
+        avtaleContext.settAvtaleVerdi(
             'startDato',
             dato.toISOString(true).split('+')[0]
         );
     };
 
-    settStartDatoRiktigFormatert = (riktigFormatert: boolean) => {
-        this.setState({ startDatoRiktigFormatert: riktigFormatert });
+    const velgSluttDato = (dato: Moment) => {
+        setSluttDatoRiktigFormatert(true);
+        avtaleContext.settAvtaleVerdi(
+            'sluttDato',
+            dato.toISOString(true).split('+')[0]
+        );
     };
 
-    settArbeidstreningLengde = (verdi: number) => {
-        this.props.settAvtaleVerdi('arbeidstreningLengde', verdi);
+    const timerIUka = Number(
+        (
+            (37.5 * avtaleContext.avtale.arbeidstreningStillingprosent) /
+            100
+        ).toFixed(2)
+    );
 
-        if (verdi === 0) {
-            this.setState({
-                arbTreningLengdeFeil: {
-                    feilmelding: 'Lengde på arbeidstreningen er påkrevd',
-                },
-            });
-        } else {
-            this.setState({ arbTreningLengdeFeil: undefined });
-        }
-    };
+    const dagerIUka = Number(((timerIUka / 37.5) * 5).toFixed(2));
 
-    render() {
-        const timerIUka = Number(
-            (
-                (37.5 * this.props.avtale.arbeidstreningStillingprosent) /
-                100
-            ).toFixed(2)
-        );
-        const dagerIUka = Number(((timerIUka / 37.5) * 5).toFixed(2));
+    const cls = BEMHelper('arbeidstidsteg');
 
-        return (
-            <Innholdsboks utfyller="arbeidsgiver">
-                <Systemtittel className="arbeidstidsteg__tittel" tag="h2">
-                    Arbeidstid og oppstart
-                </Systemtittel>
-                <Normaltekst className="arbeidstidsteg__startdato-label">
-                    Startdato
-                </Normaltekst>
-                <Datovelger
-                    className="arbeidstidsteg__datovelger"
-                    velgDato={this.velgStartDato}
-                    dato={moment(this.props.avtale.startDato)}
-                    settRiktigFormatert={this.settStartDatoRiktigFormatert}
-                    inputRiktigFormatert={this.state.startDatoRiktigFormatert}
-                />
-                <Ukevelger
-                    feilmelding={this.state.arbTreningLengdeFeil}
-                    label="Hvor lenge skal arbeidstreningen vare?"
-                    verdi={this.props.avtale.arbeidstreningLengde}
-                    onChange={this.settArbeidstreningLengde}
-                    min={1}
-                    max={12}
-                />
-                <StillingsprosentInput
-                    feilmelding={this.state.stillingsprosentFeil}
-                    label="Hvilken stillingsprosent skal deltakeren ha?"
-                    verdi={this.props.avtale.arbeidstreningStillingprosent}
-                    settVerdi={_.partial(
-                        this.props.settAvtaleVerdi,
-                        'arbeidstreningStillingprosent'
-                    )}
-                />
-                <InfoBoks timerIUka={timerIUka} dagerIUka={dagerIUka} />
+    return (
+        <Innholdsboks utfyller="arbeidsgiver">
+            <Systemtittel className={cls.element('tittel')} tag="h2">
+                Arbeidstid og oppstart
+            </Systemtittel>
+            <Normaltekst>Startdato</Normaltekst>
+            <Datovelger
+                className={cls.element('datovelger')}
+                velgDato={velgStartDato}
+                dato={moment(avtaleContext.avtale.startDato)}
+                settRiktigFormatert={() => setStartDatoRiktigFormatert(true)}
+                inputRiktigFormatert={startDatoRiktigFormatert}
+            />
+            <Normaltekst>Sluttdato</Normaltekst>
+            <Datovelger
+                className={cls.element('datovelger')}
+                velgDato={velgSluttDato}
+                dato={moment(avtaleContext.avtale.sluttDato)}
+                settRiktigFormatert={() => setSluttDatoRiktigFormatert(true)}
+                inputRiktigFormatert={sluttDatoRiktigFormatert}
+            />
+            <StillingsprosentInput
+                label="Hvilken stillingsprosent skal deltakeren ha?"
+                verdi={avtaleContext.avtale.arbeidstreningStillingprosent}
+                settVerdi={_.partial(
+                    avtaleContext.settAvtaleVerdi,
+                    'arbeidstreningStillingprosent'
+                )}
+            />
+            <InfoBoks timerIUka={timerIUka} dagerIUka={dagerIUka} />
 
-                <LagreKnapp
-                    className="arbeidstidsteg__lagre-knapp"
-                    label={'Lagre'}
-                    lagre={this.props.lagreAvtale}
-                    suksessmelding={'Avtale lagret'}
-                />
-            </Innholdsboks>
-        );
-    }
-}
+            <LagreKnapp
+                className={cls.element('lagre-knapp')}
+                label={'Lagre'}
+                lagre={avtaleContext.lagreAvtale}
+                suksessmelding={'Avtale lagret'}
+            />
+        </Innholdsboks>
+    );
+};
 
-export default medContext(ArbeidstidSteg);
+export default ArbeidstidSteg;

--- a/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.tsx
+++ b/src/AvtaleSide/ArbeidstidSteg/ArbeidstidSteg.tsx
@@ -10,7 +10,7 @@ import StillingsprosentInput from './StillingsprosentInput/StillingsprosentInput
 import InfoBoks from './InfoBoks/InfoBoks';
 import './ArbeidstidSteg.less';
 import BEMHelper from '@/utils/bem';
-import { Arbeidstid, Avtale } from '@/types/avtale';
+import { Arbeidstid } from '@/types/avtale';
 import { medContext } from '@/AvtaleContext';
 import { InputStegProps } from '@/AvtaleSide/input-steg-props';
 

--- a/src/AvtaleSide/ArbeidstidSteg/StillingsprosentInput/StillingsprosentInput.tsx
+++ b/src/AvtaleSide/ArbeidstidSteg/StillingsprosentInput/StillingsprosentInput.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import { Input } from 'nav-frontend-skjema';
 import './StillingsprosentInput.less';
-import { SkjemaelementFeil } from 'nav-frontend-skjema/lib/skjemaelement-feilmelding';
 import useValidering from '@/komponenter/useValidering';
 
 interface Props {
     label: string;
     verdi: number;
-    feilmelding?: SkjemaelementFeil;
     settVerdi: (verdi: number) => void;
 }
 

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/varighet/VarighetOppsummering.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/varighet/VarighetOppsummering.tsx
@@ -22,10 +22,10 @@ const harDato = (dato: number): string => {
 const VarighetOppsummering: FunctionComponent<Arbeidstid> = ({
     startDato,
     sluttDato,
-    arbeidstreningStillingprosent,
+    stillingprosent,
 }) => {
-    const stillingProsent = arbeidstreningStillingprosent
-        ? arbeidstreningStillingprosent.toString() + '%'
+    const stillingProsent = stillingprosent
+        ? stillingprosent.toString() + '%'
         : '';
 
     return (

--- a/src/AvtaleSide/GodkjenningSteg/Oppsummering/varighet/VarighetOppsummering.tsx
+++ b/src/AvtaleSide/GodkjenningSteg/Oppsummering/varighet/VarighetOppsummering.tsx
@@ -1,6 +1,5 @@
 import moment from 'moment';
-import EtikettFokus from 'nav-frontend-etiketter/lib/etikettfokus';
-import { Element, Normaltekst } from 'nav-frontend-typografi';
+import { Element } from 'nav-frontend-typografi';
 import * as React from 'react';
 import { FunctionComponent } from 'react';
 import BEMHelper from '@/utils/bem';
@@ -12,28 +11,6 @@ import VarighetIkon from './VarighetIkon';
 
 const cls = BEMHelper('varighetOppsummering');
 
-const settInnRadStatus = (status: boolean, content: any): React.ReactNode => {
-    if (status) {
-        return (
-            <Normaltekst className={cls.element('navn')}>{content}</Normaltekst>
-        );
-    }
-    return standardTomBlokk();
-};
-
-const ukeSulfix = (antall: number): string => {
-    return antall > 1 ? ' uker' : ' uke';
-};
-
-export const sjekkOmVerdiErSatt = (input: number): boolean => {
-    if (input) {
-        if (input > 0) {
-            return true;
-        }
-    }
-    return false;
-};
-
 const formaterDato = (dato: number): string => {
     return moment(dato).format('DD.MM.YYYY');
 };
@@ -42,13 +19,9 @@ const harDato = (dato: number): string => {
     return dato ? formaterDato(dato).toString() : '';
 };
 
-const standardTomBlokk = (): React.ReactNode => {
-    return <EtikettFokus>Ikke fylt ut</EtikettFokus>;
-};
-
 const VarighetOppsummering: FunctionComponent<Arbeidstid> = ({
     startDato,
-    arbeidstreningLengde,
+    sluttDato,
     arbeidstreningStillingprosent,
 }) => {
     const stillingProsent = arbeidstreningStillingprosent
@@ -70,15 +43,12 @@ const VarighetOppsummering: FunctionComponent<Arbeidstid> = ({
                     </div>
                     <div className={cls.element('element')}>
                         <Element className={cls.element('label')}>
-                            Varighet
+                            Sluttdato
                         </Element>
-                        {settInnRadStatus(
-                            sjekkOmVerdiErSatt(arbeidstreningLengde),
-                            arbeidstreningLengde
-                                ? arbeidstreningLengde.toString() +
-                                      ukeSulfix(arbeidstreningLengde)
-                                : ''
-                        )}
+                        <SjekkOmVerdiEksisterer
+                            verdi={harDato(sluttDato)}
+                            clsName="varighetOppsummering"
+                        />
                     </div>
                     <div className={cls.element('element')}>
                         <Element className={cls.element('label')}>

--- a/src/AvtaleSide/KontaktInformasjonSteg/ArbeidsgiverinfoDel/ArbeidsgiverinfoDel.spec.tsx
+++ b/src/AvtaleSide/KontaktInformasjonSteg/ArbeidsgiverinfoDel/ArbeidsgiverinfoDel.spec.tsx
@@ -1,9 +1,15 @@
-
 import React from 'react';
 import { shallow } from 'enzyme';
 import ArbeidsgiverinfoDel from './ArbeidsgiverinfoDel';
+import avtaleMock from '@/mocking/avtale-mock';
 
 test('Test that <ArbeidsgiverinfoDel> renders correctly', () => {
-    const wrapper = shallow(<ArbeidsgiverinfoDel/>);
+    const wrapper = shallow(
+        <ArbeidsgiverinfoDel
+            avtale={avtaleMock}
+            settAvtaleVerdi={() => {}}
+            lagreAvtale={() => Promise.resolve()}
+        />
+    );
     expect(wrapper).toHaveLength(1);
 });

--- a/src/AvtaleSide/KontaktInformasjonSteg/ArbeidsgiverinfoDel/ArbeidsgiverinfoDel.tsx
+++ b/src/AvtaleSide/KontaktInformasjonSteg/ArbeidsgiverinfoDel/ArbeidsgiverinfoDel.tsx
@@ -2,12 +2,15 @@ import * as _ from 'lodash';
 import { Input, SkjemaGruppe } from 'nav-frontend-skjema';
 import { Systemtittel } from 'nav-frontend-typografi';
 import * as React from 'react';
-import { Context, medContext } from '@/AvtaleContext';
 import PakrevdInput from '@/komponenter/PakrevdInput/PakrevdInput';
 import TelefonnummerInput from '@/komponenter/TelefonnummerInput/TelefonnummerInput';
 import './ArbeidsgiverinfoDel.less';
+import { Arbeidsgiverinfo, Bedriftinfo } from '@/types/avtale';
+import { InputStegProps } from '@/AvtaleSide/input-steg-props';
 
-const ArbeidsgiverinfoDel = (props: Context) => (
+const ArbeidsgiverinfoDel = (
+    props: InputStegProps<Bedriftinfo & Arbeidsgiverinfo>
+) => (
     <>
         <Systemtittel className="arbeidsgiver-tittel">
             Informasjon om arbeidsgiver
@@ -66,4 +69,4 @@ const ArbeidsgiverinfoDel = (props: Context) => (
     </>
 );
 
-export default medContext(ArbeidsgiverinfoDel);
+export default ArbeidsgiverinfoDel;

--- a/src/AvtaleSide/KontaktInformasjonSteg/DeltakerinfoDel/DeltakerinfoDel.spec.tsx
+++ b/src/AvtaleSide/KontaktInformasjonSteg/DeltakerinfoDel/DeltakerinfoDel.spec.tsx
@@ -1,9 +1,15 @@
-
 import React from 'react';
 import { shallow } from 'enzyme';
 import DeltakerinfoDel from './DeltakerinfoDel';
+import avtaleMock from '@/mocking/avtale-mock';
 
 test('Test that <DeltakerinfoDel> renders correctly', () => {
-    const wrapper = shallow(<DeltakerinfoDel/>);
+    const wrapper = shallow(
+        <DeltakerinfoDel
+            avtale={avtaleMock}
+            settAvtaleVerdi={() => {}}
+            lagreAvtale={() => Promise.resolve()}
+        />
+    );
     expect(wrapper).toHaveLength(1);
 });

--- a/src/AvtaleSide/KontaktInformasjonSteg/DeltakerinfoDel/DeltakerinfoDel.tsx
+++ b/src/AvtaleSide/KontaktInformasjonSteg/DeltakerinfoDel/DeltakerinfoDel.tsx
@@ -2,11 +2,9 @@ import * as _ from 'lodash';
 import { Input } from 'nav-frontend-skjema';
 import { Systemtittel } from 'nav-frontend-typografi';
 import * as React from 'react';
-import { Context, medContext } from '@/AvtaleContext';
 import PakrevdInput from '@/komponenter/PakrevdInput/PakrevdInput';
 import TelefonnummerInput from '@/komponenter/TelefonnummerInput/TelefonnummerInput';
 import './DeltakerinfoDel.less';
-import KontaktinfoSteg from '@/AvtaleSide/KontaktInformasjonSteg/KontaktinfoSteg';
 import { Deltakerinfo } from '@/types/avtale';
 import { InputStegProps } from '@/AvtaleSide/input-steg-props';
 

--- a/src/AvtaleSide/KontaktInformasjonSteg/DeltakerinfoDel/DeltakerinfoDel.tsx
+++ b/src/AvtaleSide/KontaktInformasjonSteg/DeltakerinfoDel/DeltakerinfoDel.tsx
@@ -6,8 +6,11 @@ import { Context, medContext } from '@/AvtaleContext';
 import PakrevdInput from '@/komponenter/PakrevdInput/PakrevdInput';
 import TelefonnummerInput from '@/komponenter/TelefonnummerInput/TelefonnummerInput';
 import './DeltakerinfoDel.less';
+import KontaktinfoSteg from '@/AvtaleSide/KontaktInformasjonSteg/KontaktinfoSteg';
+import { Deltakerinfo } from '@/types/avtale';
+import { InputStegProps } from '@/AvtaleSide/input-steg-props';
 
-const DeltakerinfoDel = (props: Context) => (
+const DeltakerinfoDel = (props: InputStegProps<Deltakerinfo>) => (
     <>
         <Systemtittel className="deltakerinfo__tittel">
             Informasjon om deltaker
@@ -44,4 +47,4 @@ const DeltakerinfoDel = (props: Context) => (
     </>
 );
 
-export default medContext(DeltakerinfoDel);
+export default DeltakerinfoDel;

--- a/src/AvtaleSide/KontaktInformasjonSteg/KontaktinfoSteg.tsx
+++ b/src/AvtaleSide/KontaktInformasjonSteg/KontaktinfoSteg.tsx
@@ -1,4 +1,4 @@
-import { Context, medContext } from '@/AvtaleContext';
+import { medContext } from '@/AvtaleContext';
 import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
 import LagreKnapp from '@/komponenter/LagreKnapp/LagreKnapp';
 import * as React from 'react';
@@ -6,12 +6,23 @@ import ArbeidsgiverinfoDel from './ArbeidsgiverinfoDel/ArbeidsgiverinfoDel';
 import DeltakerinfoDel from './DeltakerinfoDel/DeltakerinfoDel';
 import './KontaktinfoSteg.less';
 import VeilederinfoDel from './VeilederinfoDel/VeilederinfoDel';
+import { InputStegProps } from '@/AvtaleSide/input-steg-props';
+import {
+    Arbeidsgiverinfo,
+    Bedriftinfo,
+    Deltakerinfo,
+    Veilederinfo,
+} from '@/types/avtale';
 
-const KontaktinfoSteg = (props: Context) => (
+const KontaktinfoSteg = (
+    props: InputStegProps<
+        Deltakerinfo & Bedriftinfo & Arbeidsgiverinfo & Veilederinfo
+    >
+) => (
     <Innholdsboks>
-        <DeltakerinfoDel />
-        <ArbeidsgiverinfoDel />
-        <VeilederinfoDel />
+        <DeltakerinfoDel {...props} />
+        <ArbeidsgiverinfoDel {...props} />
+        <VeilederinfoDel {...props} />
         <LagreKnapp
             className="kontaktinfo-steg__lagre-knapp"
             lagre={props.lagreAvtale}

--- a/src/AvtaleSide/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.spec.tsx
+++ b/src/AvtaleSide/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.spec.tsx
@@ -1,9 +1,15 @@
-
 import React from 'react';
 import { shallow } from 'enzyme';
 import VeilederinfoDel from './VeilederinfoDel';
+import avtaleMock from '@/mocking/avtale-mock';
 
 test('Test that <VeilederinfoDel> renders correctly', () => {
-    const wrapper = shallow(<VeilederinfoDel/>);
+    const wrapper = shallow(
+        <VeilederinfoDel
+            avtale={avtaleMock}
+            settAvtaleVerdi={() => {}}
+            lagreAvtale={() => Promise.resolve()}
+        />
+    );
     expect(wrapper).toHaveLength(1);
 });

--- a/src/AvtaleSide/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
+++ b/src/AvtaleSide/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
@@ -5,8 +5,10 @@ import { Context, medContext } from '@/AvtaleContext';
 import PakrevdInput from '@/komponenter/PakrevdInput/PakrevdInput';
 import TelefonnummerInput from '@/komponenter/TelefonnummerInput/TelefonnummerInput';
 import './VeilederinfoDel.less';
+import { Veilederinfo } from '@/types/avtale';
+import { InputStegProps } from '@/AvtaleSide/input-steg-props';
 
-const VeilederinfoDel = (props: Context) => (
+const VeilederinfoDel = (props: InputStegProps<Veilederinfo>) => (
     <>
         <Systemtittel className="veilederinfo__tittel">
             Kontaktperson i NAV
@@ -39,4 +41,4 @@ const VeilederinfoDel = (props: Context) => (
     </>
 );
 
-export default medContext(VeilederinfoDel);
+export default VeilederinfoDel;

--- a/src/AvtaleSide/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
+++ b/src/AvtaleSide/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
@@ -1,7 +1,6 @@
 import * as _ from 'lodash';
 import { Systemtittel } from 'nav-frontend-typografi';
 import * as React from 'react';
-import { Context, medContext } from '@/AvtaleContext';
 import PakrevdInput from '@/komponenter/PakrevdInput/PakrevdInput';
 import TelefonnummerInput from '@/komponenter/TelefonnummerInput/TelefonnummerInput';
 import './VeilederinfoDel.less';

--- a/src/AvtaleSide/OppfolgingOgTilretteleggingSteg/OppfolgingOgTilretteleggingSteg.tsx
+++ b/src/AvtaleSide/OppfolgingOgTilretteleggingSteg/OppfolgingOgTilretteleggingSteg.tsx
@@ -2,13 +2,17 @@ import * as _ from 'lodash';
 import HjelpetekstBase from 'nav-frontend-hjelpetekst';
 import { Systemtittel } from 'nav-frontend-typografi';
 import * as React from 'react';
-import { Context, medContext } from '../../AvtaleContext';
+import { medContext } from '../../AvtaleContext';
 import Innholdsboks from '../../komponenter/Innholdsboks/Innholdsboks';
 import LagreKnapp from '../../komponenter/LagreKnapp/LagreKnapp';
 import PakrevdTextarea from '../../komponenter/PakrevdTextarea/PakrevdTextarea';
 import './OppfolgingOgTilretteleggingSteg.less';
+import { InputStegProps } from '@/AvtaleSide/input-steg-props';
+import { Oppfolging, Tilrettelegging } from '@/types/avtale';
 
-const OppfolgingTilretteleggingSteg = (props: Context) => (
+const OppfolgingTilretteleggingSteg = (
+    props: InputStegProps<Oppfolging & Tilrettelegging>
+) => (
     <div>
         <Innholdsboks utfyller="veileder_og_arbeidsgiver">
             <Systemtittel className="oppfolgingsteg__tittel">

--- a/src/AvtaleSide/input-steg-props.ts
+++ b/src/AvtaleSide/input-steg-props.ts
@@ -1,0 +1,7 @@
+import { Avtale } from '@/types/avtale';
+
+export type InputStegProps<T extends Partial<Avtale>> = {
+    avtale: T;
+    settAvtaleVerdi: (felt: keyof T, verdi: any) => void;
+    lagreAvtale: () => Promise<any>;
+};

--- a/src/mocking/avtale-mock.ts
+++ b/src/mocking/avtale-mock.ts
@@ -49,7 +49,7 @@ const avtaleMock: Avtale = {
     tilrettelegging: 'AG skal tilrettelegge',
 
     startDato: 99,
-    arbeidstreningLengde: 8,
+    sluttDato: 99,
     arbeidstreningStillingprosent: 99,
 
     veilederNavIdent: 'Z123456',

--- a/src/mocking/avtale-mock.ts
+++ b/src/mocking/avtale-mock.ts
@@ -50,7 +50,7 @@ const avtaleMock: Avtale = {
 
     startDato: 99,
     sluttDato: 99,
-    arbeidstreningStillingprosent: 99,
+    stillingprosent: 99,
 
     veilederNavIdent: 'Z123456',
     veilederFornavn: 'Nav',

--- a/src/types/avtale.ts
+++ b/src/types/avtale.ts
@@ -56,7 +56,7 @@ export interface Veilederinfo {
 export interface Arbeidstid {
     startDato: number;
     sluttDato: number;
-    arbeidstreningStillingprosent: number;
+    stillingprosent: number;
 }
 
 export interface MaalListe {

--- a/src/types/avtale.ts
+++ b/src/types/avtale.ts
@@ -55,7 +55,7 @@ export interface Veilederinfo {
 
 export interface Arbeidstid {
     startDato: number;
-    arbeidstreningLengde: number;
+    sluttDato: number;
     arbeidstreningStillingprosent: number;
 }
 


### PR DESCRIPTION
Breaking change, der frontend og backend må deployes samtidig. Backend PR: https://github.com/navikt/tiltaksgjennomforing-api/pull/100

* Datovelger for sluttdato under steget Arbeidstid.
* Ny type `InputStegProps`, som kan brukes av steg som trenger å lese `Avtale` fra context, sette avtaleverdi, og lagre avtalen. Tidligere har steg hatt `Context` som props, ved å bytte til `InputStegProps` innskrenker vi komponentens påkrevde props, slik at det blir mer tydelig hva komponenten gjør og det blir lettere å teste.
* Refaktor steg til å bruke `InputStegProps`.
* Renamer `arbeidstreningStillingprosent` til `stillingprosent`