### PR TITLE
Prettier som pre-commit hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1863,10 +1863,22 @@
             "integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==",
             "dev": true
         },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+            "dev": true
+        },
         "@types/node": {
             "version": "10.17.4",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.4.tgz",
             "integrity": "sha512-F2pgg+LcIr/elguz+x+fdBX5KeZXGUOp7TV8M0TVIrDezYLFRNt8oMTyps0VQ1kj5WGGoR18RdxnRDHXrIFHMQ==",
+            "dev": true
+        },
+        "@types/normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
             "dev": true
         },
         "@types/prop-types": {
@@ -2479,6 +2491,12 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-differ": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
             "dev": true
         },
         "array-equal": {
@@ -7469,6 +7487,12 @@
             "integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==",
             "dev": true
         },
+        "get-stdin": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+            "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+            "dev": true
+        },
         "get-stream": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -8013,6 +8037,135 @@
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
+        },
+        "husky": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-3.1.0.tgz",
+            "integrity": "sha512-FJkPoHHB+6s4a+jwPqBudBDvYZsoQW5/HBuMSehC8qDiCe50kpcxeqFoDSlow+9I6wg47YxBoT3WxaURlrDIIQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.2",
+                "ci-info": "^2.0.0",
+                "cosmiconfig": "^5.2.1",
+                "execa": "^1.0.0",
+                "get-stdin": "^7.0.0",
+                "opencollective-postinstall": "^2.0.2",
+                "pkg-dir": "^4.2.0",
+                "please-upgrade-node": "^3.2.0",
+                "read-pkg": "^5.2.0",
+                "run-node": "^1.0.0",
+                "slash": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+                    "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1",
+                        "lines-and-columns": "^1.1.6"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "pkg-dir": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+                    "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^4.0.0"
+                    }
+                },
+                "read-pkg": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                    "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/normalize-package-data": "^2.4.0",
+                        "normalize-package-data": "^2.5.0",
+                        "parse-json": "^5.0.0",
+                        "type-fest": "^0.6.0"
+                    }
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                    "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                    "dev": true
+                }
+            }
         },
         "hyphenate-style-name": {
             "version": "1.0.3",
@@ -10604,6 +10757,12 @@
                 "type-check": "~0.3.2"
             }
         },
+        "lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+            "dev": true
+        },
         "load-json-file": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -11237,6 +11396,12 @@
                 "run-queue": "^1.0.3"
             }
         },
+        "mri": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+            "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+            "dev": true
+        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -11258,6 +11423,33 @@
             "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
             "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
             "dev": true
+        },
+        "multimatch": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+            "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+            "dev": true,
+            "requires": {
+                "@types/minimatch": "^3.0.3",
+                "array-differ": "^3.0.0",
+                "array-union": "^2.1.0",
+                "arrify": "^2.0.1",
+                "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "array-union": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+                    "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+                    "dev": true
+                },
+                "arrify": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+                    "dev": true
+                }
+            }
         },
         "mute-stream": {
             "version": "0.0.7",
@@ -12528,6 +12720,15 @@
                 }
             }
         },
+        "please-upgrade-node": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+            "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+            "dev": true,
+            "requires": {
+                "semver-compare": "^1.0.0"
+            }
+        },
         "pn": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
@@ -13530,9 +13731,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "1.18.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-            "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+            "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
             "dev": true
         },
         "pretty-bytes": {
@@ -13576,6 +13777,194 @@
                     "dev": true,
                     "requires": {
                         "color-convert": "^1.9.0"
+                    }
+                }
+            }
+        },
+        "pretty-quick": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-2.0.1.tgz",
+            "integrity": "sha512-y7bJt77XadjUr+P1uKqZxFWLddvj3SKY6EU4BuQtMxmmEFSMpbN132pUWdSG1g1mtUfO0noBvn7wBf0BVeomHg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.2",
+                "execa": "^2.1.0",
+                "find-up": "^4.1.0",
+                "ignore": "^5.1.4",
+                "mri": "^1.1.4",
+                "multimatch": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+                    "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    }
+                },
+                "execa": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+                    "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^3.0.0",
+                        "onetime": "^5.1.0",
+                        "p-finally": "^2.0.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "ignore": {
+                    "version": "5.1.4",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+                    "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+                    "dev": true
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+                    "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                },
+                "onetime": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+                    "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^2.1.0"
+                    }
+                },
+                "p-finally": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+                    "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+                    "dev": true
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
                     }
                 }
             }
@@ -14766,6 +15155,12 @@
                 "is-promise": "^2.1.0"
             }
         },
+        "run-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+            "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+            "dev": true
+        },
         "run-queue": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -14925,6 +15320,12 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true
+        },
+        "semver-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
             "dev": true
         },
         "send": {
@@ -15884,6 +16285,12 @@
             "version": "1.0.0",
             "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
+        "strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true
         },
         "strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -105,10 +105,12 @@
         "fetch-mock": "^7.7.3",
         "glob": "^7.1.5",
         "http-proxy-middleware": "^0.19.1",
+        "husky": "^3.1.0",
         "less": "^3.8.1",
         "less-watch-compiler": "^1.13.0",
         "npm-run-all": "^4.1.5",
-        "prettier": "^1.16.4",
+        "prettier": "^1.19.1",
+        "pretty-quick": "^2.0.1",
         "react-scripts": "^3.2.0",
         "tslint": "^5.20.1",
         "tslint-config-prettier": "^1.18.0",
@@ -121,5 +123,10 @@
         "not dead",
         "not ie < 10",
         "not op_mini all"
-    ]
+    ],
+    "husky": {
+        "hooks": {
+            "pre-commit": "pretty-quick --staged --pattern \"**/*.*(js|jsx|ts|tsx|css|scss|less)\""
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     ],
     "husky": {
         "hooks": {
-            "pre-commit": "pretty-quick --staged --pattern \"**/*.*(js|jsx|ts|tsx|css|scss|less)\""
+            "pre-commit": "pretty-quick --staged --pattern \"**/*.*(js|json|jsx|ts|tsx|css|scss|less)\""
         }
     }
 }


### PR DESCRIPTION
For å sikre at prettier kjøres kontinuerlig legger jeg til husky og pretty-quick. Formatering kjøres da før man commiter. Dette blir et sikkerhetsnett mot feilformatering. Anbefaler likevel at utviklere kjører prettier on-save, for å unngå at "alt" forandrer seg ved commit.

Filtypene som formateres er js, jsx, ts, tsx, css, scss, less. Er det flere relevante?

