### PR TITLE
Sist endret som optimistisk lås i stedet for versjonsnummer

### DIFF
--- a/src/AvtaleContext.tsx
+++ b/src/AvtaleContext.tsx
@@ -11,7 +11,7 @@ import amplitude from '@/utils/amplitude';
 export const tomAvtale: Avtale = {
     id: '',
     opprettetTidspunkt: '',
-    versjon: '',
+    sistEndret: '',
 
     deltakerFnr: '',
     deltakerFornavn: '',

--- a/src/mocking/avtale-mock.ts
+++ b/src/mocking/avtale-mock.ts
@@ -27,8 +27,8 @@ const oppgaveListe: Oppgave[] = [
 
 const avtaleMock: ArbeidstreningAvtale = {
     id: '9565e74d-66f3-44a1-8a3c-91fae6b450d3',
-    opprettetTidspunkt: '4 uker siden',
-    versjon: '34',
+    opprettetTidspunkt: '',
+    sistEndret: '',
 
     godkjentAvDeltaker: false,
     godkjentAvArbeidsgiver: false,

--- a/src/services/rest-service.ts
+++ b/src/services/rest-service.ts
@@ -91,16 +91,11 @@ const lagreAvtale = async (avtale: Avtale): Promise<Avtale> => {
         body: JSON.stringify(avtale),
         headers: {
             'Content-Type': 'application/json',
-            'If-Match': avtale.versjon,
+            'If-Unmodified-Since': avtale.sistEndret,
         },
     });
     await handleResponse(response);
-    const versjon = response.headers.get('ETag');
-    if (versjon !== avtale.versjon) {
-        return await hentAvtale(avtale.id);
-    } else {
-        return avtale;
-    }
+    return await hentAvtale(avtale.id);
 };
 
 const opprettAvtale = async (deltakerFnr: string, bedriftNr: string, tiltakstype: TiltaksType): Promise<Avtale> => {
@@ -133,7 +128,7 @@ const godkjennAvtale = async (avtale: Avtale) => {
     const response = await fetch(uri, {
         method: 'POST',
         headers: {
-            'If-Match': avtale.versjon,
+            'If-Unmodified-Since': avtale.sistEndret,
         },
     });
     await handleResponse(response);
@@ -147,7 +142,7 @@ const godkjennAvtalePaVegne = async (avtale: Avtale, paVegneGrunn: GodkjentPaVeg
         body: JSON.stringify(paVegneGrunn),
         headers: {
             'Content-Type': 'application/json',
-            'If-Match': avtale.versjon,
+            'If-Unmodified-Since': avtale.sistEndret,
         },
     });
     await handleResponse(response);
@@ -167,7 +162,7 @@ const avbrytAvtale = async (avtale: Avtale) => {
     const response = await fetch(uri, {
         method: 'POST',
         headers: {
-            'If-Match': avtale.versjon,
+            'If-Unmodified-Since': avtale.sistEndret,
         },
     });
     await handleResponse(response);

--- a/src/types/avtale.ts
+++ b/src/types/avtale.ts
@@ -52,7 +52,7 @@ export type TiltaksType = 'ARBEIDSTRENING' | 'MIDLERTIDIG_LONNSTILSKUDD' | 'VARI
 export interface AvtaleMetadata {
     id: string;
     opprettetTidspunkt: string;
-    versjon: string;
+    sistEndret: string;
     tiltakstype: TiltaksType;
 }
 


### PR DESCRIPTION
Det blir begrepskollisjon når vi innfører versjonering av avtale. Så for å forenkle endrer jeg til timestamp til optimistisk lås, i stedet for versjonummer. I tillegg vil vi kunne bruke feltet sistEndret til noe fornuftig, for eksempel til å sortere avtaleoversikten.

PR i backend: https://github.com/navikt/tiltaksgjennomforing-api/pull/110

Frontend og backend må deployes samtidig.