### PR TITLE
Lagt pa credentials pa fetcGet-metoden for Edge cookie stotte

### DIFF
--- a/src/services/rest-service.ts
+++ b/src/services/rest-service.ts
@@ -38,7 +38,7 @@ export interface RestService {
 }
 
 const fetchGet: (url: string) => Promise<Response> = url => {
-    return fetch(url, { headers: { Pragma: 'no-cache' } });
+    return fetch(url, { headers: { Pragma: 'no-cache' }, credentials: 'same-origin' });
 };
 
 const handleResponse = async (response: Response) => {


### PR DESCRIPTION
Microsoft Edge sender nå som default ikke med cookies ved fetch-kall. Dermed feiler alle innloggede-kall som avhenger av feks. selvbetjening-idtoken. Kodendringen tvinger med cookies i fetch-kall som ligger på samme domene.