### PR TITLE
MS Edge sessionStorage Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "react": "^16.12.0",
         "react-app-polyfill": "^0.2.1",
         "react-collapse": "^4.0.3",
+        "react-cookie": "^4.0.3",
         "react-copy-to-clipboard": "^5.0.1",
         "react-day-picker": "^7.4.0",
         "react-dom": "^16.11.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
+import messages from '@/messages';
 import * as React from 'react';
+import { CookiesProvider } from 'react-cookie';
 import { addLocaleData, IntlProvider } from 'react-intl';
 import * as nb from 'react-intl/locale-data/nb';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
@@ -20,7 +22,6 @@ import {
     pathTilStegIAvtale,
 } from './paths';
 import RedirectEtterLogin from './RedirectEtterLogin';
-import messages from '@/messages';
 
 addLocaleData(nb);
 
@@ -31,34 +32,36 @@ class App extends React.Component {
                 <BrowserRouter basename={basename}>
                     <Switch>
                         <Route path={pathTilInformasjonssideUinnlogget} exact={true} component={Informasjonsside} />
-                        <InnloggingBoundary>
-                            <RedirectEtterLogin>
-                                <FeatureToggleProvider>
-                                    <Route path="/" exact={true} component={AvtaleOversikt} />
-                                    <Route
-                                        path={pathTilInformasjonssideInnlogget}
-                                        exact={true}
-                                        component={Informasjonsside}
-                                    />
-                                    <Route path={pathTilOpprettAvtale} exact={true} component={OpprettAvtale} />
-                                    <Route
-                                        path={pathTilOpprettAvtaleFullfort(':avtaleId')}
-                                        exact={true}
-                                        component={OpprettelseFullfort}
-                                    />
-                                    <AvtaleProvider>
+                        <CookiesProvider>
+                            <InnloggingBoundary>
+                                <RedirectEtterLogin>
+                                    <FeatureToggleProvider>
+                                        <Route path="/" exact={true} component={AvtaleOversikt} />
                                         <Route
-                                            path={[
-                                                pathTilAvtale(':avtaleId'),
-                                                pathTilStegIAvtale(':avtaleId', ':stegPath'),
-                                            ]}
+                                            path={pathTilInformasjonssideInnlogget}
                                             exact={true}
-                                            component={AvtaleSide}
+                                            component={Informasjonsside}
                                         />
-                                    </AvtaleProvider>
-                                </FeatureToggleProvider>
-                            </RedirectEtterLogin>
-                        </InnloggingBoundary>
+                                        <Route path={pathTilOpprettAvtale} exact={true} component={OpprettAvtale} />
+                                        <Route
+                                            path={pathTilOpprettAvtaleFullfort(':avtaleId')}
+                                            exact={true}
+                                            component={OpprettelseFullfort}
+                                        />
+                                        <AvtaleProvider>
+                                            <Route
+                                                path={[
+                                                    pathTilAvtale(':avtaleId'),
+                                                    pathTilStegIAvtale(':avtaleId', ':stegPath'),
+                                                ]}
+                                                exact={true}
+                                                component={AvtaleSide}
+                                            />
+                                        </AvtaleProvider>
+                                    </FeatureToggleProvider>
+                                </RedirectEtterLogin>
+                            </InnloggingBoundary>
+                        </CookiesProvider>
                     </Switch>
                 </BrowserRouter>
             </IntlProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,6 @@ class App extends React.Component {
                 <BrowserRouter basename={basename}>
                     <Switch>
                         <Route path={pathTilInformasjonssideUinnlogget} exact={true} component={Informasjonsside} />
-
                         <InnloggingBoundary>
                             <RedirectEtterLogin>
                                 <FeatureToggleProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import messages from '@/messages';
 import * as React from 'react';
-import { CookiesProvider } from 'react-cookie';
 import { addLocaleData, IntlProvider } from 'react-intl';
 import * as nb from 'react-intl/locale-data/nb';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
@@ -32,36 +31,35 @@ class App extends React.Component {
                 <BrowserRouter basename={basename}>
                     <Switch>
                         <Route path={pathTilInformasjonssideUinnlogget} exact={true} component={Informasjonsside} />
-                        <CookiesProvider>
-                            <InnloggingBoundary>
-                                <RedirectEtterLogin>
-                                    <FeatureToggleProvider>
-                                        <Route path="/" exact={true} component={AvtaleOversikt} />
+
+                        <InnloggingBoundary>
+                            <RedirectEtterLogin>
+                                <FeatureToggleProvider>
+                                    <Route path="/" exact={true} component={AvtaleOversikt} />
+                                    <Route
+                                        path={pathTilInformasjonssideInnlogget}
+                                        exact={true}
+                                        component={Informasjonsside}
+                                    />
+                                    <Route path={pathTilOpprettAvtale} exact={true} component={OpprettAvtale} />
+                                    <Route
+                                        path={pathTilOpprettAvtaleFullfort(':avtaleId')}
+                                        exact={true}
+                                        component={OpprettelseFullfort}
+                                    />
+                                    <AvtaleProvider>
                                         <Route
-                                            path={pathTilInformasjonssideInnlogget}
+                                            path={[
+                                                pathTilAvtale(':avtaleId'),
+                                                pathTilStegIAvtale(':avtaleId', ':stegPath'),
+                                            ]}
                                             exact={true}
-                                            component={Informasjonsside}
+                                            component={AvtaleSide}
                                         />
-                                        <Route path={pathTilOpprettAvtale} exact={true} component={OpprettAvtale} />
-                                        <Route
-                                            path={pathTilOpprettAvtaleFullfort(':avtaleId')}
-                                            exact={true}
-                                            component={OpprettelseFullfort}
-                                        />
-                                        <AvtaleProvider>
-                                            <Route
-                                                path={[
-                                                    pathTilAvtale(':avtaleId'),
-                                                    pathTilStegIAvtale(':avtaleId', ':stegPath'),
-                                                ]}
-                                                exact={true}
-                                                component={AvtaleSide}
-                                            />
-                                        </AvtaleProvider>
-                                    </FeatureToggleProvider>
-                                </RedirectEtterLogin>
-                            </InnloggingBoundary>
-                        </CookiesProvider>
+                                    </AvtaleProvider>
+                                </FeatureToggleProvider>
+                            </RedirectEtterLogin>
+                        </InnloggingBoundary>
                     </Switch>
                 </BrowserRouter>
             </IntlProvider>

--- a/src/AvtaleOversikt/IngenAvtaler/IngenAvtaler.tsx
+++ b/src/AvtaleOversikt/IngenAvtaler/IngenAvtaler.tsx
@@ -5,13 +5,15 @@ import BEMHelper from '@/utils/bem';
 import classNames from 'classnames';
 import { Ingress, Innholdstittel, Undertittel } from 'nav-frontend-typografi';
 import React, { FunctionComponent } from 'react';
+import { useCookies } from 'react-cookie';
 import './IngenAvtaler.less';
 import IngenAvtalerArbeidsgiver from './IngenAvtalerArbeidsgiver';
 
 const cls = BEMHelper('ingenAvtaler');
 
 const IngenAvtaler: FunctionComponent<{}> = () => {
-    const innloggetPart = sessionStorage.getItem(INNLOGGET_PART);
+    const [cookies] = useCookies([INNLOGGET_PART]);
+    const innloggetPart = cookies[INNLOGGET_PART];
 
     if (innloggetPart === 'veileder') {
         return (

--- a/src/AvtaleOversikt/IngenAvtaler/IngenAvtaler.tsx
+++ b/src/AvtaleOversikt/IngenAvtaler/IngenAvtaler.tsx
@@ -12,7 +12,7 @@ import IngenAvtalerArbeidsgiver from './IngenAvtalerArbeidsgiver';
 const cls = BEMHelper('ingenAvtaler');
 
 const IngenAvtaler: FunctionComponent<{}> = () => {
-    const [cookies] = useCookies([INNLOGGET_PART]);
+    const [cookies] = useCookies();
     const innloggetPart = cookies[INNLOGGET_PART];
 
     if (innloggetPart === 'veileder') {

--- a/src/InnloggingBoundary/InnloggingBoundary.tsx
+++ b/src/InnloggingBoundary/InnloggingBoundary.tsx
@@ -16,7 +16,7 @@ export const InnloggetBrukerContext = React.createContext<InnloggetBruker>({
 
 const InnloggingBoundary: FunctionComponent<RouteComponentProps> = props => {
     const { innloggetBruker, uinnlogget, innloggingskilder, feilmelding } = useInnlogget();
-    const [cookies, setCookie] = useCookies([INNLOGGET_PART]);
+    const [cookies, setCookie] = useCookies();
 
     if (uinnlogget) {
         return <Innloggingside innloggingskilder={innloggingskilder} />;

--- a/src/InnloggingBoundary/InnloggingBoundary.tsx
+++ b/src/InnloggingBoundary/InnloggingBoundary.tsx
@@ -16,7 +16,7 @@ export const InnloggetBrukerContext = React.createContext<InnloggetBruker>({
 
 const InnloggingBoundary: FunctionComponent<RouteComponentProps> = props => {
     const { innloggetBruker, uinnlogget, innloggingskilder, feilmelding } = useInnlogget();
-    const [cookies, setCookie, removeCookie] = useCookies([INNLOGGET_PART]);
+    const [cookies, setCookie] = useCookies([INNLOGGET_PART]);
 
     if (uinnlogget) {
         return <Innloggingside innloggingskilder={innloggingskilder} />;

--- a/src/InnloggingBoundary/InnloggingBoundary.tsx
+++ b/src/InnloggingBoundary/InnloggingBoundary.tsx
@@ -2,6 +2,7 @@ import VarselKomponent from '@/komponenter/Varsel/VarselKomponent';
 import { INNLOGGET_PART } from '@/RedirectEtterLogin';
 import * as React from 'react';
 import { FunctionComponent } from 'react';
+import { useCookies } from 'react-cookie';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import Innloggingslinje from './Innloggingslinje';
 import Innloggingside from './Innloggingsside';
@@ -15,16 +16,17 @@ export const InnloggetBrukerContext = React.createContext<InnloggetBruker>({
 
 const InnloggingBoundary: FunctionComponent<RouteComponentProps> = props => {
     const { innloggetBruker, uinnlogget, innloggingskilder, feilmelding } = useInnlogget();
+    const [cookies, setCookie, removeCookie] = useCookies([INNLOGGET_PART]);
 
     if (uinnlogget) {
         return <Innloggingside innloggingskilder={innloggingskilder} />;
     } else if (innloggetBruker) {
-        if (!sessionStorage.getItem(INNLOGGET_PART)) {
+        if (!cookies[INNLOGGET_PART]) {
             const urlParametere = new URLSearchParams(props.location.search);
 
             const innloggetPart = urlParametere.get('part');
             if (innloggetPart && ['arbeidsgiver', 'deltaker', 'veileder'].includes(innloggetPart)) {
-                sessionStorage.setItem(INNLOGGET_PART, innloggetPart);
+                setCookie(INNLOGGET_PART, innloggetPart);
                 urlParametere.delete('part');
                 props.history.replace(props.location.pathname + '?' + urlParametere.toString());
             } else {

--- a/src/InnloggingBoundary/Innloggingsside.tsx
+++ b/src/InnloggingBoundary/Innloggingsside.tsx
@@ -10,6 +10,7 @@ import { HoyreChevron } from 'nav-frontend-chevron';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { Ingress, Sidetittel, Systemtittel } from 'nav-frontend-typografi';
 import * as React from 'react';
+import { useCookies } from 'react-cookie';
 import MediaQuery from 'react-responsive';
 import { Link } from 'react-router-dom';
 import './Innloggingsside.less';
@@ -19,6 +20,8 @@ import { VarselOmNedetid } from './VarselOmNedetid';
 const cls = BEMHelper('innloggingsside');
 
 const Innloggingside = (props: { innloggingskilder: Innloggingskilde[] }) => {
+    const [cookies, setCookie, removeCookie] = useCookies([INNLOGGET_PART]);
+
     const loginKlikk = async (innloggingskilde: Innloggingskilde) => {
         try {
             await restService.hentInnloggetBruker();
@@ -35,7 +38,7 @@ const Innloggingside = (props: { innloggingskilder: Innloggingskilde[] }) => {
             key={innlogginskilde.url}
             className="innloggingsside__logginnKnapp"
             onClick={() => {
-                sessionStorage.setItem(INNLOGGET_PART, innlogginskilde.part);
+                setCookie(INNLOGGET_PART, innlogginskilde.part);
                 loginKlikk(innlogginskilde);
             }}
         >

--- a/src/InnloggingBoundary/Innloggingsside.tsx
+++ b/src/InnloggingBoundary/Innloggingsside.tsx
@@ -20,7 +20,7 @@ import { VarselOmNedetid } from './VarselOmNedetid';
 const cls = BEMHelper('innloggingsside');
 
 const Innloggingside = (props: { innloggingskilder: Innloggingskilde[] }) => {
-    const [, setCookie] = useCookies([INNLOGGET_PART]);
+    const [, setCookie] = useCookies();
 
     const loginKlikk = async (innloggingskilde: Innloggingskilde) => {
         try {

--- a/src/InnloggingBoundary/Innloggingsside.tsx
+++ b/src/InnloggingBoundary/Innloggingsside.tsx
@@ -20,7 +20,7 @@ import { VarselOmNedetid } from './VarselOmNedetid';
 const cls = BEMHelper('innloggingsside');
 
 const Innloggingside = (props: { innloggingskilder: Innloggingskilde[] }) => {
-    const [cookies, setCookie, removeCookie] = useCookies([INNLOGGET_PART]);
+    const [, setCookie] = useCookies([INNLOGGET_PART]);
 
     const loginKlikk = async (innloggingskilde: Innloggingskilde) => {
         try {

--- a/src/InnloggingBoundary/LoggUtKnapp.tsx
+++ b/src/InnloggingBoundary/LoggUtKnapp.tsx
@@ -5,16 +5,16 @@ import React from 'react';
 import { useCookies } from 'react-cookie';
 
 const LoggUtKnapp: React.FunctionComponent<KnappBaseProps> = props => {
-    const [cookies, setCookie, removeCookie] = useCookies([INNLOGGET_PART]);
+    const [, , removeCookie] = useCookies([INNLOGGET_PART]);
 
-    const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const onClick = () => {
         removeCookie(INNLOGGET_PART);
         amplitude.logEvent('bruker-logget-ut', {}, () => {
             window.location.href = '/tiltaksgjennomforing/logout';
         });
     };
     return (
-        <Knapp className="innloggingslinje__loggutknapp" mini={true} onClick={onClick} {...props}>
+        <Knapp mini={true} onClick={onClick} {...props}>
             Logg ut
         </Knapp>
     );

--- a/src/InnloggingBoundary/LoggUtKnapp.tsx
+++ b/src/InnloggingBoundary/LoggUtKnapp.tsx
@@ -1,9 +1,14 @@
-import React from 'react';
+import { INNLOGGET_PART } from '@/RedirectEtterLogin';
 import amplitude from '@/utils/amplitude';
 import { Knapp, KnappBaseProps } from 'nav-frontend-knapper';
+import React from 'react';
+import { useCookies } from 'react-cookie';
 
 const LoggUtKnapp: React.FunctionComponent<KnappBaseProps> = props => {
+    const [cookies, setCookie, removeCookie] = useCookies([INNLOGGET_PART]);
+
     const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        removeCookie(INNLOGGET_PART);
         amplitude.logEvent('bruker-logget-ut', {}, () => {
             window.location.href = '/tiltaksgjennomforing/logout';
         });

--- a/src/InnloggingBoundary/LoggUtKnapp.tsx
+++ b/src/InnloggingBoundary/LoggUtKnapp.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { useCookies } from 'react-cookie';
 
 const LoggUtKnapp: React.FunctionComponent<KnappBaseProps> = props => {
-    const [, , removeCookie] = useCookies([INNLOGGET_PART]);
+    const [, , removeCookie] = useCookies();
 
     const onClick = () => {
         removeCookie(INNLOGGET_PART);


### PR DESCRIPTION
Vi har brukt `sessionStorage` til å ta vare på hvilket rolle bruker har valgt å logge seg inn på (arbeidsgiver/deltaker/veileder). Dette er nå flyttet til en `cookie` isteden.

`sessionStorage` i `Edge` blir clearet når man navigerer mellom sikkerhetssoner, så når man blir redirectet av loginservice forsvinner denne.