### PR TITLE
TAG-1139 Vise Lønn i  100% stilling

### DIFF
--- a/src/AvtaleSide/steg/BeregningTilskudd/BeregningTilskuddSteg.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/BeregningTilskuddSteg.tsx
@@ -10,6 +10,7 @@ import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
 import LagreKnapp from '@/komponenter/LagreKnapp/LagreKnapp';
 import VerticalSpacer from '@/komponenter/layout/VerticalSpacer';
 import BEMHelper from '@/utils/bem';
+import { hundreProsentLonn } from '@/utils/utregningUtils';
 import { Column, Row } from 'nav-frontend-grid';
 import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
 import React, { useContext } from 'react';
@@ -86,11 +87,7 @@ const BeregningTilskuddSteg = (props: Context) => {
                             name="manedslonn100%"
                             bredde="S"
                             label="Lønn ved 100% stilling"
-                            value={
-                                avtale.manedslonn != null
-                                    ? (avtale.manedslonn / avtale.stillingprosent) * 100
-                                    : undefined
-                            }
+                            value={hundreProsentLonn(avtale.manedslonn, avtale.stillingprosent)}
                         />
                     </Column>
                 )}

--- a/src/AvtaleSide/steg/BeregningTilskudd/BeregningTilskuddSteg.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/BeregningTilskuddSteg.tsx
@@ -1,5 +1,6 @@
 import { Context, medContext } from '@/AvtaleContext';
 import VisUtregningenPanel from '@/AvtaleSide/steg/BeregningTilskudd/VisUtregningenPanel';
+import { InnloggetBrukerContext } from '@/InnloggingBoundary/InnloggingBoundary';
 import KontonummerInput from '@/komponenter/form/KontonummerInput';
 import RadioPanelGruppeHorisontal from '@/komponenter/form/RadioPanelGruppeHorisontal';
 import SelectInput from '@/komponenter/form/SelectInput';
@@ -11,7 +12,7 @@ import VerticalSpacer from '@/komponenter/layout/VerticalSpacer';
 import BEMHelper from '@/utils/bem';
 import { Column, Row } from 'nav-frontend-grid';
 import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
-import React from 'react';
+import React, { useContext } from 'react';
 import './BeregningTilskuddSteg.less';
 
 const cls = BEMHelper('beregningTilskuddSteg');
@@ -44,6 +45,7 @@ const arbeidsgiveravgiftAlternativer = () => {
     return satserVerdier;
 };
 const BeregningTilskuddSteg = (props: Context) => {
+    const innloggetBruker = useContext(InnloggetBrukerContext);
     const { settAvtaleVerdi, avtale } = props;
     return (
         <Innholdsboks utfyller="veileder_og_arbeidsgiver">
@@ -77,6 +79,21 @@ const BeregningTilskuddSteg = (props: Context) => {
                         max={65000}
                     />
                 </Column>
+                {innloggetBruker.erNavAnsatt && avtale.stillingprosent < 100 && (
+                    <Column md="6">
+                        <ValutaInput
+                            disabled={true}
+                            name="manedslonn100%"
+                            bredde="S"
+                            label="Lønn ved 100% stilling"
+                            value={
+                                avtale.manedslonn != null
+                                    ? (avtale.manedslonn / avtale.stillingprosent) * 100
+                                    : undefined
+                            }
+                        />
+                    </Column>
+                )}
             </Row>
             <Row className="">
                 <Column md="12">

--- a/src/utils/utregningUtils.ts
+++ b/src/utils/utregningUtils.ts
@@ -1,0 +1,5 @@
+const hundreProsentLonn = (manedslonn?: number, stillingsprosent?: number) => {
+    return manedslonn && stillingsprosent ? (manedslonn / stillingsprosent) * 100 : undefined;
+};
+
+export { hundreProsentLonn };


### PR DESCRIPTION
Viser hva lønn ville utgjort i en 100% stilling, der stillingsprosent > 100%. Vises kun for veileder og lagres ikke på avtaleobjekt eller i DB, havner dermed heller ikke på PDF som journalføres.

![image](https://user-images.githubusercontent.com/5412607/74225104-5c09de00-4cba-11ea-99d5-cfccdab39a1f.png)
