### PR TITLE
Endret navn pa avtaleobjektfeltet fra stillingtype til stillingstittel

### DIFF
--- a/src/AvtaleSide/steg/GodkjenningSteg/Oppsummering/StillingsOppsummering/StillingsOppsummering.tsx
+++ b/src/AvtaleSide/steg/GodkjenningSteg/Oppsummering/StillingsOppsummering/StillingsOppsummering.tsx
@@ -1,14 +1,14 @@
+import VerticalSpacer from '@/komponenter/layout/VerticalSpacer';
+import { Stilling } from '@/types/avtale';
+import { Element } from 'nav-frontend-typografi';
 import React, { FunctionComponent } from 'react';
 import SjekkOmVerdiEksisterer from '../SjekkOmVerdiEksisterer/SjekkOmVerdiEksisterer';
 import Stegoppsummering from '../Stegoppsummering/Stegoppsummering';
-import { Stilling } from '@/types/avtale';
-import { Element } from 'nav-frontend-typografi';
-import VerticalSpacer from '@/komponenter/layout/VerticalSpacer';
 
 const StillingsOppsummering: FunctionComponent<Stilling> = props => (
     <Stegoppsummering tittel="Stilling">
         <Element>Stillingstittel</Element>
-        <SjekkOmVerdiEksisterer verdi={props.stillingtype} />
+        <SjekkOmVerdiEksisterer verdi={props.stillingstittel} />
         <VerticalSpacer sixteenPx={true} />
         <Element>Arbeidsoppgaver</Element>
         <SjekkOmVerdiEksisterer verdi={props.arbeidsoppgaver} />

--- a/src/AvtaleSide/steg/StillingSteg/StillingSteg.tsx
+++ b/src/AvtaleSide/steg/StillingSteg/StillingSteg.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
-import PakrevdInput from '@/komponenter/PakrevdInput/PakrevdInput';
 import { Context, medContext } from '@/AvtaleContext';
-import PakrevdTextarea from '@/komponenter/PakrevdTextarea/PakrevdTextarea';
-import LagreKnapp from '@/komponenter/LagreKnapp/LagreKnapp';
 import SkjemaTittel from '@/komponenter/form/SkjemaTittel';
+import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
+import LagreKnapp from '@/komponenter/LagreKnapp/LagreKnapp';
+import PakrevdInput from '@/komponenter/PakrevdInput/PakrevdInput';
+import PakrevdTextarea from '@/komponenter/PakrevdTextarea/PakrevdTextarea';
+import React from 'react';
 
 const StillingSteg = (props: Context) => {
     return (
@@ -12,8 +12,8 @@ const StillingSteg = (props: Context) => {
             <SkjemaTittel>Stilling</SkjemaTittel>
             <PakrevdInput
                 label="Stillingstittel"
-                verdi={props.avtale.stillingtype || ''}
-                settVerdi={verdi => props.settAvtaleVerdi('stillingtype', verdi)}
+                verdi={props.avtale.stillingstittel || ''}
+                settVerdi={verdi => props.settAvtaleVerdi('stillingstittel', verdi)}
             />
             <PakrevdTextarea
                 label="Beskriv arbeidsoppgavene som inngår i stillingen"

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -34,7 +34,7 @@ export const avtaleFelterBokmal: { [key in keyof AltAvtaleinnhold]: string } = {
     sluttDato: 'sluttdato',
     startDato: 'startdato',
     stillingprosent: 'stillingsprosent',
-    stillingtype: 'stillingstype',
+    stillingstittel: 'stillingstittel',
     tilrettelegging: 'tilrettelegging',
     veilederEtternavn: 'veileders etternavn',
     veilederFornavn: 'veileders fornavn',

--- a/src/mocking/lonnstilskudd-avtale-mock.ts
+++ b/src/mocking/lonnstilskudd-avtale-mock.ts
@@ -53,7 +53,7 @@ const lonnstilskuddAvtaleMock: Avtale<LonnstilskuddAvtaleinnhold> = {
     manedslonn: 10000,
     arbeidsgiverKontonummer: '123',
     arbeidsoppgaver: '',
-    stillingtype: '',
+    stillingstittel: '',
 };
 
 export default lonnstilskuddAvtaleMock;

--- a/src/types/avtale.ts
+++ b/src/types/avtale.ts
@@ -76,7 +76,7 @@ export interface Varighet {
 }
 
 export interface Stilling {
-    stillingtype?: string;
+    stillingstittel?: string;
     arbeidsoppgaver?: string;
 }
 

--- a/src/utils/avtaleObjektUtils.ts
+++ b/src/utils/avtaleObjektUtils.ts
@@ -23,7 +23,7 @@ const tomtAvtaleInnholdInput: Required<AltAvtaleinnhold> = {
     veilederTlf: '',
     manedslonn: 0,
     arbeidsoppgaver: '',
-    stillingtype: '',
+    stillingstittel: '',
     mentorFornavn: '',
     mentorEtternavn: '',
     mentorOppgaver: '',


### PR DESCRIPTION
Endret navn på databasefeltet `stillingtype` til `stillingstittel` i backend. Den PR-en har dermed direkte knytning til PR på backend med samme navn. (https://github.com/navikt/tiltaksgjennomforing-api/pull/166)