### PR TITLE
Avbryt avtale modal fiksing

### DIFF
--- a/src/AvtaleContext.tsx
+++ b/src/AvtaleContext.tsx
@@ -252,6 +252,7 @@ export class TempAvtaleProvider extends React.Component<any, State> {
 
     settAvtaleVerdi(felt: keyof Avtale, verdi: any) {
         if (noenHarGodkjentMenIkkeAlle(this.state.avtale)) {
+            debugger;
             this.setState({ opphevGodkjenningerModalIsOpen: true });
         } else {
             const avtale = this.state.avtale;
@@ -290,6 +291,7 @@ export class TempAvtaleProvider extends React.Component<any, State> {
 
     utforHandlingHvisRedigerbar = (callback: () => void) => {
         if (noenHarGodkjentMenIkkeAlle(this.state.avtale)) {
+            debugger;
             this.setState({ opphevGodkjenningerModalIsOpen: true });
         } else {
             callback();

--- a/src/AvtaleContext.tsx
+++ b/src/AvtaleContext.tsx
@@ -103,7 +103,7 @@ const tomTemporaryLagringArbeidsoppgave: TemporaryLagringArbeidsoppgave = {
 };
 
 export interface Context {
-    avbryt: () => Promise<any>;
+    avbryt: (avbruttDato: string, avbruttGrunn: string) => Promise<any>;
     avtale: Avtale;
     endretSteg: () => void;
     godkjenn: (godkjent: boolean) => Promise<any>;
@@ -252,7 +252,6 @@ export class TempAvtaleProvider extends React.Component<any, State> {
 
     settAvtaleVerdi(felt: keyof Avtale, verdi: any) {
         if (noenHarGodkjentMenIkkeAlle(this.state.avtale)) {
-            debugger;
             this.setState({ opphevGodkjenningerModalIsOpen: true });
         } else {
             const avtale = this.state.avtale;
@@ -291,7 +290,6 @@ export class TempAvtaleProvider extends React.Component<any, State> {
 
     utforHandlingHvisRedigerbar = (callback: () => void) => {
         if (noenHarGodkjentMenIkkeAlle(this.state.avtale)) {
-            debugger;
             this.setState({ opphevGodkjenningerModalIsOpen: true });
         } else {
             callback();
@@ -359,9 +357,9 @@ export class TempAvtaleProvider extends React.Component<any, State> {
         await this.hentAvtale(avtale.id);
     }
 
-    async avbrytAvtale() {
+    async avbrytAvtale(avbruttDato: string, avbruttGrunn: string) {
         const avtale = this.state.avtale;
-        await RestService.avbrytAvtale(avtale);
+        await RestService.avbrytAvtale(avtale, avbruttDato, avbruttGrunn);
         this.sendToAmplitude('#tiltak-avtale-avbrutt');
         await this.hentAvtale(avtale.id);
     }

--- a/src/AvtaleSide/DesktopAvtaleSide/DesktopAvtaleSide.tsx
+++ b/src/AvtaleSide/DesktopAvtaleSide/DesktopAvtaleSide.tsx
@@ -16,7 +16,7 @@ interface Props {
     rolle: Rolle;
     varsler?: JSX.Element[];
     avtale: Avtale;
-    avbrytAvtale: () => Promise<void>;
+    avbrytAvtale: (avbruttDato: string, avbruttGrunn: string) => Promise<void>;
     tilbakeTilOversiktKlikk: () => void;
 }
 

--- a/src/komponenter/modal/AvbrytAvtaleModal.tsx
+++ b/src/komponenter/modal/AvbrytAvtaleModal.tsx
@@ -51,10 +51,12 @@ const AvbrytAvtaleModal: FunctionComponent<Props & InputStegProps<Avbrytelse>> =
         props.settAvtaleVerdi('avbruttDato', dato);
     };
 
-    useEffect(() => {
-        velgStartDato(DAGENS_DATO);
-        // eslint-disable-next-line
-    }, []);
+    // useEffect(() => {
+    //     if (props.isOpen) {
+    //         velgStartDato(DAGENS_DATO);
+    //     }
+    //     // eslint-disable-next-line
+    // }, [props.isOpen]);
 
     useEffect(() => {
         if (props.avtale.avbruttGrunn) {

--- a/src/komponenter/modal/AvbrytAvtaleModal.tsx
+++ b/src/komponenter/modal/AvbrytAvtaleModal.tsx
@@ -16,7 +16,7 @@ import BekreftelseModal from './BekreftelseModal';
 type Props = {
     isOpen: boolean;
     lukkModal: () => void;
-    avbrytAvtale: () => Promise<any>;
+    avbrytAvtale: (avbruttDato: string, avbruttGrunn: string) => Promise<any>;
 };
 
 const DAGENS_DATO = moment().format(moment.HTML5_FMT.DATE);
@@ -26,46 +26,45 @@ const AvbrytAvtaleModal: FunctionComponent<Props & InputStegProps<Avbrytelse>> =
     const [annetGrunn, setAnnetGrunn] = useState('');
     const [grunnFeil, setGrunnFeil] = useState<undefined | SkjemaelementFeil>(undefined);
     const [datoFeil, setDatoFeil] = useState<undefined | SkjemaelementFeil>(undefined);
+    const [avbruttGrunn, setAvbruttGrunn] = useState<AvbrytelseGrunn | string>('');
+    const [avbruttDato, setAvbruttDato] = useState('');
 
     const bekreftAvbrytAvtale = async () => {
-        if (!props.avtale.avbruttGrunn || !props.avtale.avbruttDato) {
-            if (!props.avtale.avbruttGrunn) {
+        if (!avbruttGrunn || !avbruttDato) {
+            if (!avbruttGrunn) {
                 setGrunnFeil({ feilmelding: 'Vennligst velg en grunn' });
             }
-            if (!props.avtale.avbruttDato) {
+            if (!avbruttDato) {
                 setDatoFeil({ feilmelding: 'Vennligst velg en dato' });
             }
         } else {
-            if (props.avtale.avbruttGrunn === 'Annet') {
-                if (annetGrunn) {
-                    props.settAvtaleVerdi('avbruttGrunn', annetGrunn);
-                } else {
-                    return;
-                }
+            if (avbruttGrunn === 'Annet') {
+                if (!annetGrunn) return;
+                return await props.avbrytAvtale(avbruttDato, annetGrunn);
             }
-            return await props.avbrytAvtale();
+            return await props.avbrytAvtale(avbruttDato, avbruttGrunn);
         }
     };
 
     const velgStartDato = (dato: string | undefined) => {
-        props.settAvtaleVerdi('avbruttDato', dato);
+        dato && setAvbruttDato(dato);
     };
 
-    // useEffect(() => {
-    //     if (props.isOpen) {
-    //         velgStartDato(DAGENS_DATO);
-    //     }
-    //     // eslint-disable-next-line
-    // }, [props.isOpen]);
+    useEffect(() => {
+        if (props.isOpen) {
+            velgStartDato(DAGENS_DATO);
+        }
+        // eslint-disable-next-line
+    }, [props.isOpen]);
 
     useEffect(() => {
-        if (props.avtale.avbruttGrunn) {
+        if (avbruttGrunn) {
             setGrunnFeil(undefined);
         }
-        if (props.avtale.avbruttGrunn === 'Annet') {
+        if (avbruttGrunn === 'Annet') {
             document.querySelector<HTMLElement>('.pakrevd-textarea')!.focus();
         }
-    }, [props.avtale.avbruttGrunn]);
+    }, [avbruttGrunn]);
 
     const grunner: AvbrytelseGrunn[] = [
         'Begynt i arbeid',
@@ -89,7 +88,7 @@ const AvbrytAvtaleModal: FunctionComponent<Props & InputStegProps<Avbrytelse>> =
                 <Datovelger
                     avgrensninger={{ minDato: DAGENS_DATO }}
                     input={{ placeholder: 'dd.mm.åååå' }}
-                    valgtDato={props.avtale.avbruttDato}
+                    valgtDato={avbruttDato}
                     onChange={dato => velgStartDato(dato)}
                 />
             </SkjemaGruppe>
@@ -104,15 +103,17 @@ const AvbrytAvtaleModal: FunctionComponent<Props & InputStegProps<Avbrytelse>> =
                                     label={grunn}
                                     name="avbrytelsegrunn"
                                     value={grunn}
-                                    checked={props.avtale.avbruttGrunn === grunn}
-                                    onChange={event => props.settAvtaleVerdi('avbruttGrunn', event.currentTarget.value)}
+                                    checked={avbruttGrunn === grunn}
+                                    onChange={event => {
+                                        setAvbruttGrunn(event.currentTarget.value);
+                                    }}
                                 />
                             );
                         })}
                     </SkjemaGruppe>
                 </div>
                 <div>
-                    {props.avtale.avbruttGrunn === 'Annet' && (
+                    {avbruttGrunn === 'Annet' && (
                         <PakrevdTextarea
                             label=""
                             verdi={annetGrunn}

--- a/src/services/rest-service.ts
+++ b/src/services/rest-service.ts
@@ -24,7 +24,7 @@ export interface RestService {
     godkjennAvtale: (avtale: Avtale) => Promise<Avtale>;
     godkjennAvtalePaVegne: (avtale: Avtale, paVegneGrunn: GodkjentPaVegneGrunner) => Promise<Avtale>;
     opphevGodkjenninger: (avtaleId: string) => Promise<Avtale>;
-    avbrytAvtale: (avtale: Avtale) => Promise<Avtale>;
+    avbrytAvtale: (avtale: Avtale, avbruttDato: string, avbruttGrunn: string) => Promise<Avtale>;
     hentInnloggetBruker: () => Promise<InnloggetBruker>;
     hentInnloggingskilder: () => Promise<Innloggingskilde[]>;
     hentBedriftBrreg: (bedriftNr: string) => Promise<Bedriftinfo>;
@@ -164,10 +164,10 @@ const opphevGodkjenninger = async (avtaleId: string) => {
     await handleResponse(response);
     return hentAvtale(avtaleId);
 };
-const avbrytAvtale = async (avtale: Avtale) => {
+const avbrytAvtale = async (avtale: Avtale, avbruttDato: string, avbruttGrunn: string) => {
     const uri = `${API_URL}/avtaler/${avtale.id}/avbryt`;
     const response = await fetchPost(uri, {
-        body: JSON.stringify({ avbruttDato: avtale.avbruttDato, avbruttGrunn: avtale.avbruttGrunn }),
+        body: JSON.stringify({ avbruttDato: avbruttDato, avbruttGrunn: avbruttGrunn }),
         headers: {
             'Content-Type': 'application/json',
             'If-Unmodified-Since': avtale.sistEndret,


### PR DESCRIPTION
Oppdatert avbryt avtale modal til. Går bort fra å oppdatere AvtaleContext når man velger dato og grunn for avbrytelse, dette blir isteden sendt som parametere til rest-kallet /avbryt. Unngår da problematikken med at man teknisk sett oppdaterer avtalen med nye verdier når en part har godkjent.

Co-authored-by: Bjarte Tynning <bjarte.tynning@nav.no>
Co-authored-by: Håvard Myrvold Johannessen <havard.myrvold.johannessen@nav.no>