### PR TITLE
Fanger og viser feilmedlinger pa restkall i BekreftelseModal

### DIFF
--- a/src/komponenter/modal/AvbrytAvtaleModal.tsx
+++ b/src/komponenter/modal/AvbrytAvtaleModal.tsx
@@ -44,8 +44,7 @@ const AvbrytAvtaleModal: FunctionComponent<Props & InputStegProps<Avbrytelse>> =
     };
 
     const avbryttAvtalen = async (grunn: string) => {
-        props.lukkModal();
-        return await props.avbrytAvtale(avbruttDato, grunn);
+        return await props.avbrytAvtale(avbruttDato, grunn).then(() => props.lukkModal());
     };
 
     const bekreftAvbrytAvtale = async () => {

--- a/src/types/feilkode.ts
+++ b/src/types/feilkode.ts
@@ -3,6 +3,6 @@ export type Feilkode = 'SAMTIDIGE_ENDRINGER' | 'ALT_MA_VAERE_FYLT_UT' | 'IKKE_VA
 export const Feilmeldinger: { [key in Feilkode]: string } = {
     ALT_MA_VAERE_FYLT_UT: 'Alt må være fylt ut før du kan godkjenne',
     SAMTIDIGE_ENDRINGER:
-        'Du må oppdatere siden før du kan lagre eller godkjenne. Det er gjort endringer i avtalen som du ikke har sett.',
+        'Du må oppdatere siden før du kan lagre, godkjenne eller gjøre andre endringer. Det er gjort endringer i avtalen som du ikke har sett.',
     IKKE_VALGT_PART: 'Ikke valgt part',
 };


### PR DESCRIPTION
BekreftelseModal brukes endel steder og denne bruker ikke `LagreKnapp` som er bygd for å håndtere exceptions, dermed oppleves feil i denne modalen som at ting ikke fungerer.
Håndterer nå dette i BekreftelseModal og viser en feilmelding hvis det inntreffer.

Eksempel i **avbryt avtalen** hvor dette var tilfelle:

![image](https://user-images.githubusercontent.com/5412607/93436357-f83c3900-f8ca-11ea-9971-e45b02ee6d55.png)
