### PR TITLE
Bruker nå velge arb.giver avgift fra nedtrekkmeny

### DIFF
--- a/src/AvtaleSide/steg/BeregningTilskudd/BeregningTilskuddSteg.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/BeregningTilskuddSteg.tsx
@@ -173,7 +173,7 @@ const BeregningTilskuddSteg: FunctionComponent<InputStegProps<Beregningsgrunnlag
                         options={arbeidsgiveravgiftAlternativer()}
                         label="Sats for arbeidsgiveravgift"
                         children=""
-                        value={props.avtale.arbeidsgiveravgift || 0}
+                        value={props.avtale.arbeidsgiveravgift}
                         onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
                             props.settAvtaleVerdi('arbeidsgiveravgift', parseFloatIfFloatable(event.target.value));
                         }}


### PR DESCRIPTION
**Arbeidsgiveravgift går ikke å sette til 0.0%**
Nå må de velge 0.0 fra nedtrekksmenyen - for å få satt verdien.

![Skjermbilde 2020-09-23 kl  15 55 41](https://user-images.githubusercontent.com/5445477/94022466-68f4c100-fdb5-11ea-9760-5e12fcd49040.png)
