### PR TITLE
Fnr i labs som gir permit pa mocket abac tilgangssjekk

### DIFF
--- a/nais/labs-gcp.json
+++ b/nais/labs-gcp.json
@@ -2,7 +2,7 @@
     "ingress": "https://arbeidsgiver.labs.nais.io/tiltaksgjennomforing",
     "api-gw-url": "http://tiltaksgjennomforing-api",
     "isso-login-url": "https://tiltak-fakelogin.labs.nais.io/login?iss=isso&aud=aud-isso&NAVident=Z123456&domain=labs.nais.io&redirect=https://arbeidsgiver.labs.nais.io/tiltaksgjennomforing",
-    "selvbetjening-login-url": "https://tiltak-fakelogin.labs.nais.io/login?iss=selvbetjening&aud=aud-selvbetjening&sub=15000000067&acr=Level4&domain=labs.nais.io&redirect=https://arbeidsgiver.labs.nais.io/tiltaksgjennomforing",
+    "selvbetjening-login-url": "https://tiltak-fakelogin.labs.nais.io/login?iss=selvbetjening&aud=aud-selvbetjening&sub=20000000052&acr=Level4&domain=labs.nais.io&redirect=https://arbeidsgiver.labs.nais.io/tiltaksgjennomforing",
     "logout-url": "https://tiltak-fakelogin.labs.nais.io/logout?cookieName=selvbetjening-idtoken&cookieName=isso-idtoken&domain=labs.nais.io&redirect=https://arbeidsgiver.labs.nais.io/tiltaksgjennomforing",
     "vault-enabled": false,
     "enable-internal-menu": true,

--- a/src/AdvarselBannerTestversjon/AdvarselBannerTestversjon.tsx
+++ b/src/AdvarselBannerTestversjon/AdvarselBannerTestversjon.tsx
@@ -22,7 +22,7 @@ const AdvarselBannerTestversjon = () => {
                     arbeidsgiver.nav.no/tiltaksgjennomforing.
                     <LesMerPanel åpneLabel="Slik tester du registrering av avtaler" lukkLabel="Lukk">
                         For å teste hele flyten, kan du logge inn som veileder, opprette en avtale på fnr:
-                        <b>15000000067</b> og bedriftnr: <b>999999999</b>.
+                        <b>20000000052</b> og bedriftnr: <b>999999999</b>.
                         <br />
                         Vi ber også om at du ikke registrer ekte data i denne løsningen, da dette er en åpen
                         testversjon.


### PR DESCRIPTION
ABAC er mocket lokalt og på labs til å gi deny på alle fødselsnummere som begynner på 1 og permit på alt annet.
Lagt inn instruksjon i labs om å bruke 20000000052 isteden.