### PR TITLE
skrudd av min og max limit pa manedslonn

### DIFF
--- a/src/AvtaleSide/steg/BeregningTilskudd/BeregningTilskuddSteg.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/BeregningTilskuddSteg.tsx
@@ -113,8 +113,7 @@ const BeregningTilskuddSteg: FunctionComponent = () => {
                             settAvtaleVerdier({ manedslonn: parseFloat(event.target.value) });
                         }}
                         onBlur={() => lagreAvtale()}
-                        min={10000}
-                        max={65000}
+                        min={0}
                     />
                 </Column>
             </Row>


### PR DESCRIPTION
Skrur av min og max på lønnstilskudd månedslønn. Tar videre en titt på å forenkle ValutaInput komponenten som er gjenstand for noe over-engineering.