### PR TITLE
Oppdatert regler for opphevGodkjenning

### DIFF
--- a/src/AvtaleProvider.spec.tsx
+++ b/src/AvtaleProvider.spec.tsx
@@ -1,6 +1,6 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-import AvtaleProvider, { AvtaleContext, Context, noenHarGodkjentMenIkkeAlle } from './AvtaleProvider';
+import AvtaleProvider, { AvtaleContext, Context, noenHarGodkjentMenIkkeInngått } from './AvtaleProvider';
 import arbeidstreningAvtaleMock from './mocking/arbeidstrening-avtale-mock';
 
 test('Test at AvtaleContext  ', () => {
@@ -14,14 +14,14 @@ test('Test at AvtaleContext  ', () => {
 
 test('Godkjent av ingen', () => {
     const avtale = arbeidstreningAvtaleMock;
-    const ikkeGodkjentAvtale = noenHarGodkjentMenIkkeAlle(avtale);
+    const ikkeGodkjentAvtale = noenHarGodkjentMenIkkeInngått(avtale);
     expect(ikkeGodkjentAvtale).toBe(false);
 });
 
 test('Godkjent av noen, men ikke alle', () => {
     const avtale = arbeidstreningAvtaleMock;
     avtale.godkjentAvDeltaker = '2021-01-01T00:00:00.000';
-    const godkjentAvDeltaker = noenHarGodkjentMenIkkeAlle(avtale);
+    const godkjentAvDeltaker = noenHarGodkjentMenIkkeInngått(avtale);
     expect(godkjentAvDeltaker).toBe(true);
 });
 
@@ -29,7 +29,7 @@ test('Godkjent av deltaker og ag, men ikke alle', () => {
     const avtale = arbeidstreningAvtaleMock;
     avtale.godkjentAvDeltaker = '2021-01-01T00:00:00.000';
     avtale.godkjentAvArbeidsgiver = '2021-01-01T00:00:00.000';
-    const godkjentDeltakerOgArbeidsgiver = noenHarGodkjentMenIkkeAlle(avtale);
+    const godkjentDeltakerOgArbeidsgiver = noenHarGodkjentMenIkkeInngått(avtale);
     expect(godkjentDeltakerOgArbeidsgiver).toBe(true);
 });
 test('Godkjent av alle', () => {
@@ -37,6 +37,6 @@ test('Godkjent av alle', () => {
     avtale.godkjentAvDeltaker = '2021-01-01T00:00:00.000';
     avtale.godkjentAvArbeidsgiver = '2021-01-01T00:00:00.000';
     avtale.godkjentAvVeileder = '2021-01-01T00:00:00.000';
-    const godkjnetAvAlle = noenHarGodkjentMenIkkeAlle(avtale);
+    const godkjnetAvAlle = noenHarGodkjentMenIkkeInngått(avtale);
     expect(godkjnetAvAlle).toBe(false);
 });

--- a/src/AvtaleProvider.spec.tsx
+++ b/src/AvtaleProvider.spec.tsx
@@ -32,11 +32,3 @@ test('Godkjent av deltaker og ag, men ikke alle', () => {
     const godkjentDeltakerOgArbeidsgiver = noenHarGodkjentMenIkkeInngått(avtale);
     expect(godkjentDeltakerOgArbeidsgiver).toBe(true);
 });
-test('Godkjent av alle', () => {
-    const avtale = arbeidstreningAvtaleMock;
-    avtale.godkjentAvDeltaker = '2021-01-01T00:00:00.000';
-    avtale.godkjentAvArbeidsgiver = '2021-01-01T00:00:00.000';
-    avtale.godkjentAvVeileder = '2021-01-01T00:00:00.000';
-    const godkjnetAvAlle = noenHarGodkjentMenIkkeInngått(avtale);
-    expect(godkjnetAvAlle).toBe(false);
-});

--- a/src/AvtaleProvider.tsx
+++ b/src/AvtaleProvider.tsx
@@ -6,7 +6,7 @@ import {
     GodkjentPaVegneAvArbeidsgiverGrunner,
     GodkjentPaVegneAvDeltakerGrunner,
     GodkjentPaVegneAvDeltakerOgArbeidsgiverGrunner,
-    Maal,
+    Maal
 } from '@/types/avtale';
 import { ApiError, AutentiseringError } from '@/types/errors';
 import { Maalkategori } from '@/types/maalkategorier';
@@ -19,8 +19,10 @@ import * as RestService from './services/rest-service';
 import { Avtaleinnhold } from './types/avtale';
 import { handterFeil } from './utils/apiFeilUtils';
 
-export const noenHarGodkjentMenIkkeAlle = (avtale: Avtale) => {
-    return Boolean(avtale.godkjentAvDeltaker || avtale.godkjentAvArbeidsgiver) && !avtale.godkjentAvVeileder;
+export const noenHarGodkjentMenIkkeInngått = (avtale: Avtale) => {
+    const noenHarGodkjent = (avtale.godkjentAvDeltaker || avtale.godkjentAvArbeidsgiver || avtale.godkjentAvVeileder);
+    return noenHarGodkjent && !avtale.erAvtaleInngått;
+    //return Boolean(avtale.godkjentAvDeltaker || avtale.godkjentAvArbeidsgiver) && !avtale.godkjentAvVeileder;
 };
 
 export interface TemporaryLagring {
@@ -91,7 +93,7 @@ const AvtaleProvider: FunctionComponent = (props) => {
         if (underLagring) {
             return;
         }
-        if (noenHarGodkjentMenIkkeAlle(avtale) && !ulagredeEndringer) {
+        if (noenHarGodkjentMenIkkeInngått(avtale) && !ulagredeEndringer) {
             return;
         }
         if (!forceLagring && !ulagredeEndringer) {
@@ -130,7 +132,7 @@ const AvtaleProvider: FunctionComponent = (props) => {
         felt: K,
         verdi: T[K]
     ): Avtale | undefined => {
-        if (noenHarGodkjentMenIkkeAlle(avtale)) {
+        if (noenHarGodkjentMenIkkeInngått(avtale)) {
             setOpphevGodkjenningerModalIsOpen(true);
         } else {
             const nyAvtale = { ...avtale, gjeldendeInnhold: { ...avtale.gjeldendeInnhold, [felt]: verdi } };
@@ -141,7 +143,7 @@ const AvtaleProvider: FunctionComponent = (props) => {
     };
 
     const settAvtaleInnholdVerdier = (endringer: Partial<Avtaleinnhold>, lagre = false): Avtale | undefined => {
-        if (noenHarGodkjentMenIkkeAlle(avtale)) {
+        if (noenHarGodkjentMenIkkeInngått(avtale)) {
             setOpphevGodkjenningerModalIsOpen(true);
         } else {
             const nyAvtale = { ...avtale, gjeldendeInnhold: { ...avtale.gjeldendeInnhold, ...endringer } };
@@ -155,7 +157,7 @@ const AvtaleProvider: FunctionComponent = (props) => {
     };
 
     const settOgKalkulerBeregningsverdier = async (endringer: Partial<Beregningsgrunnlag>) => {
-        if (noenHarGodkjentMenIkkeAlle(avtale)) {
+        if (noenHarGodkjentMenIkkeInngått(avtale)) {
             setOpphevGodkjenningerModalIsOpen(true);
         } else {
             try {
@@ -170,7 +172,7 @@ const AvtaleProvider: FunctionComponent = (props) => {
     };
 
     const utforHandlingHvisRedigerbar = (callback: () => void): void => {
-        if (noenHarGodkjentMenIkkeAlle(avtale)) {
+        if (noenHarGodkjentMenIkkeInngått(avtale)) {
             setOpphevGodkjenningerModalIsOpen(true);
         } else {
             callback();

--- a/src/AvtaleProvider.tsx
+++ b/src/AvtaleProvider.tsx
@@ -20,7 +20,7 @@ import { Avtaleinnhold } from './types/avtale';
 import { handterFeil } from './utils/apiFeilUtils';
 
 export const noenHarGodkjentMenIkkeInngått = (avtale: Avtale) => {
-    const noenHarGodkjent = (avtale.godkjentAvDeltaker || avtale.godkjentAvArbeidsgiver || avtale.godkjentAvVeileder);
+    const noenHarGodkjent = Boolean(avtale.godkjentAvDeltaker || avtale.godkjentAvArbeidsgiver || avtale.godkjentAvVeileder);
     return noenHarGodkjent && !avtale.erAvtaleInngått;
     //return Boolean(avtale.godkjentAvDeltaker || avtale.godkjentAvArbeidsgiver) && !avtale.godkjentAvVeileder;
 };

--- a/src/mocking/arbeidstrening-avtale-mock.ts
+++ b/src/mocking/arbeidstrening-avtale-mock.ts
@@ -93,6 +93,7 @@ const arbeidstreningAvtaleMock: Avtale = {
     formidlingsgruppe: Formidlingsgruppe.ARBEIDSSOKER,
 
     godkjentForEtterregistrering: false,
+    erAvtaleInngått: false
 };
 
 export default arbeidstreningAvtaleMock;

--- a/src/mocking/lonnstilskudd-avtale-mock.ts
+++ b/src/mocking/lonnstilskudd-avtale-mock.ts
@@ -77,6 +77,7 @@ const lonnstilskuddAvtaleMock: Avtale = {
     avtaleNr: 1,
 
     godkjentForEtterregistrering: false,
+    erAvtaleInngått: false
 };
 
 export default lonnstilskuddAvtaleMock;

--- a/src/types/avtale.ts
+++ b/src/types/avtale.ts
@@ -1,6 +1,5 @@
 import { Formidlingsgruppe } from '@/AvtaleSide/steg/BeregningTilskudd/Formidlingsgruppe';
 import { Kvalifiseringsgruppe } from '@/AvtaleSide/steg/BeregningTilskudd/Kvalifiseringsgruppe';
-import KontaktpersonRefusjoninfoDel from '@/AvtaleSide/steg/KontaktInformasjonSteg/KontaktpersonRefusjoninfoDel/KontaktpersonRefusjoninfoDel';
 import { Nettressurs } from '@/types/nettressurs';
 import { Maalkategori } from './maalkategorier';
 
@@ -97,6 +96,7 @@ export interface AvtaleMetadata {
     sistEndret: string;
     tiltakstype: TiltaksType;
     erUfordelt: boolean;
+    erAvtaleInngått: boolean;
     enhetGeografisk?: string;
     enhetsnavnGeografisk?: string;
     enhetOppfolging?: string;

--- a/src/types/feilkode.ts
+++ b/src/types/feilkode.ts
@@ -68,7 +68,8 @@ export type Feilkode =
     | 'AVTALE_INNEHOLDER_UTBETALT_TILSKUDDSPERIODE'
     | 'UGYLDIG_VIRKSOMHETSNUMMER'
     | 'UGYLDIG_FØDSELSNUMMER'
-    | 'UGYLDIG_AVTALETYPE';
+    | 'UGYLDIG_AVTALETYPE'
+    | 'KAN_IKKE_OPPHEVE_GODKJENNINGER_VED_INNGAATT_AVTALE';
 
 export const Feilmeldinger: { [key in Feilkode]: string } = {
     ALT_MA_VAERE_FYLT_UT: 'Alt må være fylt ut før du kan godkjenne',
@@ -149,4 +150,5 @@ export const Feilmeldinger: { [key in Feilkode]: string } = {
     UGYLDIG_VIRKSOMHETSNUMMER: 'Du må oppgi gyldig virksomhetsnummer',
     UGYLDIG_FØDSELSNUMMER: 'Du må oppgi gyldig fødselsnummer for deltaker',
     UGYLDIG_AVTALETYPE: 'Du må oppgi avtaletype',
+    KAN_IKKE_OPPHEVE_GODKJENNINGER_VED_INNGAATT_AVTALE: 'Avtalen er inngått. Godkjenninger kan derfor ikke oppheves. Forsøk å oppfrisk siden.'
 };

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -2,7 +2,7 @@ import amplitude from 'amplitude-js';
 
 const erProd =
     window.location.hostname === 'arbeidsgiver.nav.no' || window.location.hostname === 'arbeidsgiver.nais.adeo.no';
-const apiKey = erProd ? 'a8243d37808422b4c768d31c88a22ef4' : '6ed1f00aabc6ced4fd6fcb7fcdc01b30';
+const apiKey = erProd ? '3a6fe32c3457e77ce81c356bb14ca886' : '55477baea93c5227d8c0f6b813653615';
 
 const instance = amplitude.getInstance();
 instance.init(apiKey, '', {

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -2,7 +2,7 @@ import amplitude from 'amplitude-js';
 
 const erProd =
     window.location.hostname === 'arbeidsgiver.nav.no' || window.location.hostname === 'arbeidsgiver.nais.adeo.no';
-const apiKey = erProd ? '3a6fe32c3457e77ce81c356bb14ca886' : '55477baea93c5227d8c0f6b813653615';
+const apiKey = erProd ? 'a8243d37808422b4c768d31c88a22ef4' : '6ed1f00aabc6ced4fd6fcb7fcdc01b30';
 
 const instance = amplitude.getInstance();
 instance.init(apiKey, '', {


### PR DESCRIPTION
Oppdatert når advarsel og mulighet for å oppheve godkjenninger skal vises.
Endret til at opphevGodkjenning vises når enten deltaker, arbeidsgiver, eller veileder har godkjent OG avtalen ikke er inngått.
Det vil fungere for både avtaler med tilskuddsperioder (som ikke blir inngått før beslutter godkjenner første periode) og for avtaler som ikke har tilskuddsperioder (som inngås ved veileders godkjenning, typisk arbeidstrening og lønnstilskudd utenfor pilot).

Co-authored-by: Mattias Lundmark <mattias.lundmark@nav.no>