### PR TITLE
Advarselmelding hvis antall dager per uke mangler i endre-menyen

### DIFF
--- a/src/AvtaleSide/Oppgavelinje/OppgaveLenker.tsx
+++ b/src/AvtaleSide/Oppgavelinje/OppgaveLenker.tsx
@@ -8,6 +8,7 @@ import ForkortAvtale from '@/AvtaleSide/steg/GodkjenningSteg/ForkortAvtale';
 import ForlengAvtale from '@/AvtaleSide/steg/GodkjenningSteg/ForlengAvtale';
 import Varsellogg from '@/AvtaleSide/Varsellogg/Varsellogg';
 import { InnloggetBrukerContext } from '@/InnloggingBoundary/InnloggingBoundary';
+import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 import React, { useContext } from 'react';
 import EndreKontaktInformasjon from '../steg/GodkjenningSteg/endringAvAvtaleInnhold/endreKontaktInfo/EndreKontaktInformasjon';
 import EndreMaal from '../steg/GodkjenningSteg/endringAvAvtaleInnhold/EndreMaal/EndreMaal';
@@ -26,10 +27,10 @@ const OppgaveLenker: React.FunctionComponent = () => {
     const erNavIdenterLike = innloggetBruker.identifikator === avtale.veilederNavIdent;
     const erVeileder = innloggetBruker.rolle === 'VEILEDER';
     const skalViseStillingsbeskrivelse =
-    avtale.tiltakstype === 'MIDLERTIDIG_LONNSTILSKUDD' ||
-    avtale.tiltakstype === 'VARIG_LONNSTILSKUDD' ||
-    avtale.tiltakstype === 'SOMMERJOBB' ||
-    avtale.tiltakstype === 'ARBEIDSTRENING';
+        avtale.tiltakstype === 'MIDLERTIDIG_LONNSTILSKUDD' ||
+        avtale.tiltakstype === 'VARIG_LONNSTILSKUDD' ||
+        avtale.tiltakstype === 'SOMMERJOBB' ||
+        avtale.tiltakstype === 'ARBEIDSTRENING';
 
     if (!erVeileder) {
         return <Varsellogg />;
@@ -37,6 +38,14 @@ const OppgaveLenker: React.FunctionComponent = () => {
 
     return (
         <>
+            {avtale.gjeldendeInnhold.antallDagerPerUke === null && avtale.godkjentAvVeileder !== null && (
+                <div style={{ maxWidth: '20rem' }}>
+                    <AlertStripeAdvarsel>
+                        <b>Antall dager per uke</b> må fylles ut før det kan gjøres endringer på avtalen. Dette gjøres i
+                        Endre stillingsbeskrivelse i denne menyen.
+                    </AlertStripeAdvarsel>
+                </div>
+            )}
             <OvertaAvtalen forskjelligNavIdent={!erNavIdenterLike} erUfordelt={avtale.erUfordelt} />
             <AnnullerAvtalen />
             <DelLenkeTilAvtalen />


### PR DESCRIPTION
Viser en advarselbanner i toppen av menyen på låse avtaler hvis feltet antall dager per uke mangler.

![image](https://user-images.githubusercontent.com/5412607/183920087-a4541f18-acd7-43ad-8b27-8a7f36992dd7.png)
