### PR TITLE
POC på å hente verdier fra url for å sette i react-state

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Starte via Yarn med REST-API (krever at https://github.com/navikt/tiltaksgjennomforing-api også kjører lokalt).
 `yarn start`
 
+Obs: Om du får en feilmelding ved `yarn start` kan du prøve å kjøre `export NODE_OPTIONS=--openssl-legacy-provider` før `yarn start`.
+
 Starte med mocket backend
 `yarn run mock`
 

--- a/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtale.spec.tsx
+++ b/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtale.spec.tsx
@@ -2,6 +2,16 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import OpprettAvtaleVeileder from './OpprettAvtaleVeileder';
 
+/**
+ * Mock useLocation
+ */
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => ({
+        pathname: 'http://localhost:3000/tiltaksgjennomforing/opprett-avtale',
+    }),
+}));
+
 test('Test that <OpprettAvtale> renders correctly', () => {
     const wrapper = shallow(<OpprettAvtaleVeileder />);
     expect(wrapper).toHaveLength(1);

--- a/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtaleVeileder.tsx
+++ b/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtaleVeileder.tsx
@@ -43,6 +43,18 @@ function useQuery() {
     return React.useMemo(() => new URLSearchParams(search), [search]);
 }
 
+function isGyldigTiltakstype(val?: string | null): val is TiltaksType | undefined {
+    const gyldigeTiltakstyper: TiltaksType[] = [
+        'ARBEIDSTRENING',
+        'INKLUDERINGSTILSKUDD',
+        'MENTOR',
+        'MIDLERTIDIG_LONNSTILSKUDD',
+        'SOMMERJOBB',
+        'VARIG_LONNSTILSKUDD',
+    ];
+    return gyldigeTiltakstyper.includes(val as TiltaksType);
+}
+
 const OpprettAvtaleVeileder: FunctionComponent = (props) => {
     const optionalTypeAvtale = useQuery().get('type');
     const optionalDeltakerFnr = useQuery().get('deltakerfnr');
@@ -53,7 +65,7 @@ const OpprettAvtaleVeileder: FunctionComponent = (props) => {
     const [bedriftNr, setBedriftNr] = useState<string>(optionalVirksomhetsnummer ?? '');
     const [bedriftNavn, setBedriftNavn] = useState<string>('');
     const [valgtTiltaksType, setTiltaksType] = useState<TiltaksType | undefined>(
-        optionalTypeAvtale ? (optionalTypeAvtale as TiltaksType) : undefined
+        isGyldigTiltakstype(optionalTypeAvtale) ? optionalTypeAvtale : undefined
     );
     const [modalIsOpen, setModalIsOpen] = useState<boolean>(false);
     const { alleredeRegistrertAvtale, setAlleredeRegistrertAvtale } = useContext(AlleredeOpprettetAvtaleContext);

--- a/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtaleVeileder.tsx
+++ b/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtaleVeileder.tsx
@@ -26,6 +26,7 @@ import './opprettAvtaleVeileder.less';
 import './OpprettAvtale.less';
 import OpprettAvtaleMedAlleredeOpprettetTiltak from '@/komponenter/alleredeOpprettetTiltak/OpprettAvtaleMedAlleredeOpprettetTiltak';
 import { AlleredeOpprettetAvtaleContext } from '@/komponenter/alleredeOpprettetTiltak/api/AlleredeOpprettetAvtaleProvider';
+import { useQuery, isGyldigTiltakstype } from '../../utils/urlQueryUtils';
 
 const cls = BEMHelper('opprett-avtale');
 
@@ -35,24 +36,6 @@ export enum Avtalerolle {
     ARBEIDSGIVER = 'ARBEIDSGIVER',
     VEILEDER = 'VEILEDER',
     BESLUTTER = 'BESLUTTER',
-}
-
-function useQuery() {
-    const { search } = useLocation();
-
-    return React.useMemo(() => new URLSearchParams(search), [search]);
-}
-
-function isGyldigTiltakstype(val?: string | null): val is TiltaksType | undefined {
-    const gyldigeTiltakstyper: TiltaksType[] = [
-        'ARBEIDSTRENING',
-        'INKLUDERINGSTILSKUDD',
-        'MENTOR',
-        'MIDLERTIDIG_LONNSTILSKUDD',
-        'SOMMERJOBB',
-        'VARIG_LONNSTILSKUDD',
-    ];
-    return gyldigeTiltakstyper.includes(val as TiltaksType);
 }
 
 const OpprettAvtaleVeileder: FunctionComponent = (props) => {

--- a/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtaleVeileder.tsx
+++ b/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtaleVeileder.tsx
@@ -18,7 +18,7 @@ import { validatorer, validerFnr } from '@/utils/fnrUtils';
 import { validerOrgnr } from '@/utils/orgnrUtils';
 import { Innholdstittel } from 'nav-frontend-typografi';
 import React, { ChangeEvent, FunctionComponent, useContext, useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import TiltaksTypeRadioPanel from '@/OpprettAvtale/OpprettAvtaleVeileder/TiltaksTypeRadioPanel';
 import InformasjonsboksTopVeilederOppretterAvtale from '@/OpprettAvtale/OpprettAvtaleVeileder/InformasjonsboksTopVeilederOppretterAvtale';
 import HvemSkalInngaaAvtalen from '@/OpprettAvtale/OpprettAvtaleVeileder/HvemSkalInngaaAvtalen';
@@ -37,13 +37,24 @@ export enum Avtalerolle {
     BESLUTTER = 'BESLUTTER',
 }
 
+function useQuery() {
+    const { search } = useLocation();
+
+    return React.useMemo(() => new URLSearchParams(search), [search]);
+}
+
 const OpprettAvtaleVeileder: FunctionComponent = (props) => {
-    const [deltakerFnr, setDeltakerFnr] = useState<string>('');
+    const optionalTypeAvtale = useQuery().get('type');
+    const optionalDeltakerFnr = useQuery().get('deltakerfnr');
+    const optionalVirksomhetsnummer = useQuery().get('virksomhetsnummer');
+    const [deltakerFnr, setDeltakerFnr] = useState<string>(optionalDeltakerFnr ?? '');
     const [mentorFnr, setMentorFnr] = useState<string>('');
     const [ugyldigAvtaletype, setUgyldigAvtaletype] = useState<boolean>(false);
-    const [bedriftNr, setBedriftNr] = useState<string>('');
+    const [bedriftNr, setBedriftNr] = useState<string>(optionalVirksomhetsnummer ?? '');
     const [bedriftNavn, setBedriftNavn] = useState<string>('');
-    const [valgtTiltaksType, setTiltaksType] = useState<TiltaksType | undefined>();
+    const [valgtTiltaksType, setTiltaksType] = useState<TiltaksType | undefined>(
+        optionalTypeAvtale ? (optionalTypeAvtale as TiltaksType) : undefined
+    );
     const [modalIsOpen, setModalIsOpen] = useState<boolean>(false);
     const { alleredeRegistrertAvtale, setAlleredeRegistrertAvtale } = useContext(AlleredeOpprettetAvtaleContext);
 

--- a/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtaleVeileder.tsx
+++ b/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtaleVeileder.tsx
@@ -1,7 +1,12 @@
 import TilbakeTilOversiktLenke from '@/AvtaleSide/TilbakeTilOversiktLenke/TilbakeTilOversiktLenke';
+import { AlleredeOpprettetAvtaleContext } from '@/komponenter/alleredeOpprettetTiltak/api/AlleredeOpprettetAvtaleProvider';
+import OpprettAvtaleMedAlleredeOpprettetTiltak from '@/komponenter/alleredeOpprettetTiltak/OpprettAvtaleMedAlleredeOpprettetTiltak';
 import Dokumenttittel from '@/komponenter/Dokumenttittel';
 import LagreKnapp from '@/komponenter/LagreKnapp/LagreKnapp';
 import useValidering from '@/komponenter/useValidering';
+import HvemSkalInngaaAvtalen from '@/OpprettAvtale/OpprettAvtaleVeileder/HvemSkalInngaaAvtalen';
+import InformasjonsboksTopVeilederOppretterAvtale from '@/OpprettAvtale/OpprettAvtaleVeileder/InformasjonsboksTopVeilederOppretterAvtale';
+import TiltaksTypeRadioPanel from '@/OpprettAvtale/OpprettAvtaleVeileder/TiltaksTypeRadioPanel';
 import { pathTilOpprettAvtaleFullfortVeileder } from '@/paths';
 import {
     hentBedriftBrreg,
@@ -17,16 +22,11 @@ import BEMHelper from '@/utils/bem';
 import { validatorer, validerFnr } from '@/utils/fnrUtils';
 import { validerOrgnr } from '@/utils/orgnrUtils';
 import { Innholdstittel } from 'nav-frontend-typografi';
-import React, { ChangeEvent, FunctionComponent, useContext, useEffect, useState } from 'react';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
-import TiltaksTypeRadioPanel from '@/OpprettAvtale/OpprettAvtaleVeileder/TiltaksTypeRadioPanel';
-import InformasjonsboksTopVeilederOppretterAvtale from '@/OpprettAvtale/OpprettAvtaleVeileder/InformasjonsboksTopVeilederOppretterAvtale';
-import HvemSkalInngaaAvtalen from '@/OpprettAvtale/OpprettAvtaleVeileder/HvemSkalInngaaAvtalen';
-import './opprettAvtaleVeileder.less';
+import { ChangeEvent, FunctionComponent, useContext, useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { isGyldigTiltakstype, useQuery } from '../../utils/urlQueryUtils';
 import './OpprettAvtale.less';
-import OpprettAvtaleMedAlleredeOpprettetTiltak from '@/komponenter/alleredeOpprettetTiltak/OpprettAvtaleMedAlleredeOpprettetTiltak';
-import { AlleredeOpprettetAvtaleContext } from '@/komponenter/alleredeOpprettetTiltak/api/AlleredeOpprettetAvtaleProvider';
-import { useQuery, isGyldigTiltakstype } from '../../utils/urlQueryUtils';
+import './opprettAvtaleVeileder.less';
 
 const cls = BEMHelper('opprett-avtale');
 

--- a/src/utils/urlQueryUtils.ts
+++ b/src/utils/urlQueryUtils.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { TiltaksType } from '../types/avtale';
+
+export function useQuery() {
+    const { search } = useLocation();
+
+    return React.useMemo(() => new URLSearchParams(search), [search]);
+}
+
+export function isGyldigTiltakstype(val?: string | null): val is TiltaksType | undefined {
+    const gyldigeTiltakstyper: TiltaksType[] = [
+        'ARBEIDSTRENING',
+        'INKLUDERINGSTILSKUDD',
+        'MENTOR',
+        'MIDLERTIDIG_LONNSTILSKUDD',
+        'SOMMERJOBB',
+        'VARIG_LONNSTILSKUDD',
+    ];
+    return gyldigeTiltakstyper.includes(val as TiltaksType);
+}


### PR DESCRIPTION
Denne PRen vil gjøre det mulig å sende med følgende query-params for å automatisk få satt verdiene i input-felter i skjemaet deres.

* `deltakerfnr` -> Deltakers fødselsnr (egen diskusjon på om man skal ha fnr i url eller ikke)
* `virksomhetsnummer` -> Virksomhetsnummer til arrangør/bedrift
* `type` -> Hvilken tiltakstype det gjelder

Årsaken til PRen er for å muliggjøre at veiledere i Mulighetsrommet i Modia (utviklet av Team valp) kan enkelt starte prosess for å opprette avtale via sin arbeidsflate der de får med seg data automatisk over til deres skjema. Det er effektivt og vi slipper dobbeltarbeid for veilederne.
