### PR TITLE
Tilbake til oversikten link

### DIFF
--- a/src/AvtaleOversikt/AvtaleTabell.tsx
+++ b/src/AvtaleOversikt/AvtaleTabell.tsx
@@ -7,14 +7,15 @@ import { Avtale } from '@/types/avtale';
 import { InnloggetBruker, Rolle } from '@/types/innlogget-bruker';
 import { Varsel } from '@/types/varsel';
 import BEMHelper from '@/utils/bem';
+import { LinkPanel } from '@navikt/ds-react';
 import classNames from 'classnames';
 import moment from 'moment';
-import { default as React, FunctionComponent, useEffect, useState } from 'react';
+import { Normaltekst } from 'nav-frontend-typografi';
+import { FunctionComponent, useEffect, useState } from 'react';
 import MediaQuery from 'react-responsive';
+import { useHistory } from 'react-router-dom';
 import './AvtaleTabell.less';
 import TaushetserklæringModal from './Taushetserklæring/Taushetserklæring';
-import { LinkPanel } from '@navikt/ds-react';
-import { Normaltekst } from 'nav-frontend-typografi';
 
 const cls = BEMHelper('avtaletabell');
 
@@ -62,6 +63,8 @@ const AvtaleTabell: FunctionComponent<{
     innloggetBruker: InnloggetBruker;
 }> = ({ avtaler, varsler, innloggetBruker }) => {
     const { filtre } = useFilter();
+    const history = useHistory();
+
     const erBeslutter: boolean = innloggetBruker.rolle === 'BESLUTTER';
     const skalViseAntallUbehandlet =
         erBeslutter && (filtre?.tilskuddPeriodeStatus === undefined || filtre?.tilskuddPeriodeStatus === 'UBEHANDLET');
@@ -121,8 +124,7 @@ const AvtaleTabell: FunctionComponent<{
                             <LinkPanel
                                 border={false}
                                 id={avtale.id}
-                                key={avtale.id}
-                                href={pathTilAvtaleNy(avtale.id, innloggetBruker.rolle)}
+                                key={avtale.id}  
                                 className={
                                     avtale.tiltakstype === 'MENTOR' && !avtale.erGodkjentTaushetserklæringAvMentor
                                         ? 'skjulIndikator'
@@ -138,6 +140,8 @@ const AvtaleTabell: FunctionComponent<{
                                     ) {
                                         setVisTaushetserklæringForAvtaleId(avtale.id);
                                         e.preventDefault();
+                                    } else {
+                                        history.push({pathname: pathTilAvtaleNy(avtale.id, innloggetBruker.rolle), search: window.location.search})
                                     }
                                 }}
                             >

--- a/src/AvtaleOversikt/AvtalekortMobil.tsx
+++ b/src/AvtaleOversikt/AvtalekortMobil.tsx
@@ -1,17 +1,18 @@
+import TaushetserklæringModal from '@/AvtaleOversikt/Taushetserklæring/Taushetserklæring';
 import VerticalSpacer from '@/komponenter/layout/VerticalSpacer';
 import StatusIkon from '@/komponenter/StatusIkon/StatusIkon';
-import { InnloggetBruker } from '@/types/innlogget-bruker';
 import { avtaleStatusTekst } from '@/messages';
 import { pathTilAvtaleNy } from '@/paths';
 import { Avtale } from '@/types/avtale';
+import { InnloggetBruker } from '@/types/innlogget-bruker';
 import { Varsel } from '@/types/varsel';
 import BEMHelper from '@/utils/bem';
-import moment from 'moment';
 import { LinkPanel } from '@navikt/ds-react';
+import moment from 'moment';
 import { Ingress, Normaltekst, Undertittel } from 'nav-frontend-typografi';
-import React, { FunctionComponent, useState } from 'react';
+import { FunctionComponent, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import './AvtalekortMobil.less';
-import TaushetserklæringModal from '@/AvtaleOversikt/Taushetserklæring/Taushetserklæring';
 
 const cls = BEMHelper('avtalekortMobil');
 
@@ -21,6 +22,7 @@ const AvtalekortMobil: FunctionComponent<{
     innloggetBruker: InnloggetBruker;
 }> = ({ avtaler, varsler, innloggetBruker }) => {
     const [visTaushetserklæringForAvtaleId, setVisTaushetserklæringForAvtaleId] = useState<string>('');
+    const history = useHistory();
 
     return (
         <>
@@ -32,7 +34,6 @@ const AvtalekortMobil: FunctionComponent<{
                             border={false}
                             key={avtale.id}
                             className={cls.className}
-                            href={pathTilAvtaleNy(avtale.id)}
                             onClick={(e) => {
                                 if (
                                     innloggetBruker.rolle === 'MENTOR' &&
@@ -41,6 +42,8 @@ const AvtalekortMobil: FunctionComponent<{
                                 ) {
                                     setVisTaushetserklæringForAvtaleId(avtale.id);
                                     e.preventDefault();
+                                } else {
+                                    history.push({pathname: pathTilAvtaleNy(avtale.id), search: window.location.search})
                                 }
                             }}
                         >

--- a/src/AvtaleSide/TilbakeTilOversiktLenke/TilbakeTilOversiktLenke.tsx
+++ b/src/AvtaleSide/TilbakeTilOversiktLenke/TilbakeTilOversiktLenke.tsx
@@ -1,9 +1,9 @@
+import { pathTilOversikt } from '@/paths';
+import BEMHelper from '@/utils/bem';
 import { Back } from '@navikt/ds-icons';
 import { FunctionComponent } from 'react';
-import { useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import './TilbakeTilOversiktLenke.less';
-import BEMHelper from '@/utils/bem';
-import { Button } from '@navikt/ds-react';
 
 type Props = {
     onClick?: () => void;
@@ -12,24 +12,18 @@ type Props = {
 
 const TilbakeTilOversiktLenke: FunctionComponent<Props> = (props) => {
     const cls = BEMHelper('tilbaketiloversikt');
-    const history = useHistory();
-
-    const handleOnClick = () => {
-        if (props.onClick) {
-            props.onClick();
-        }
-        history.goBack();
-    };
-
     return (
-        <Button
-            variant="tertiary"
-            onClick={handleOnClick}
-            icon={<Back className={cls.element('chevron')} />}
-            iconPosition="left"
+        <Link
+            to={{ pathname: pathTilOversikt, search: window.location.search }}
+            className={cls.element('lenke')}
+            onClick={props.onClick}
+            role="menuitem"
         >
+            <div aria-hidden={true}>
+                <Back className={cls.element('chevron')} />
+            </div>
             {props.tekst || 'Tilbake til oversikt'}
-        </Button>
+        </Link>
     );
 };
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -28,7 +28,7 @@ export const pathTilAvtale = (avtaleId: string, rolle: Rolle = 'INGEN_ROLLE'): s
     rolle === 'BESLUTTER' ? `${avtaleBase}/${avtaleId}/beslutte/` : `${avtaleBase}/${avtaleId}`;
 
 export const pathTilAvtaleNy = (avtaleId: string, rolle: Rolle = 'INGEN_ROLLE'): string =>
-    rolle === 'BESLUTTER' ? `${basename}${avtaleBase}/${avtaleId}/beslutte/` : `${basename}${avtaleBase}/${avtaleId}`;
+    rolle === 'BESLUTTER' ? `${avtaleBase}/${avtaleId}/beslutte/` : `${avtaleBase}/${avtaleId}`;
 
 export const pathTilStegIAvtale = (avtaleId: string, steg: string) => `${pathTilAvtale(avtaleId)}/${steg}`;
 


### PR DESCRIPTION
Går tilbake til link på TilbakeTilOversiktLenke.
Tar nå vare på url query params når du går inn i en avtale, bevarer dermed søk og tilbaketiloversikt lenken går kun til oversikten uten noe back.
Bruker history isteden for href i LinkPanel for å navigere inn på en avtale. history har innebygd funksjonalitet for å bevare query parametere. Det går da i tillegg raskere å navigere inn på avtaler, da href trigger full reload av siden, mens history.push navigerer i react SPA style.