### PR TITLE
Flytter info om kontaktperson refusjon sammen med info om avtaleparte…

### DIFF
--- a/src/AvtaleSide/steg/GodkjenningSteg/GodkjenningSteg.tsx
+++ b/src/AvtaleSide/steg/GodkjenningSteg/GodkjenningSteg.tsx
@@ -11,7 +11,6 @@ import BEMHelper from '@/utils/bem';
 import React, { createElement, FunctionComponent, Suspense, useContext } from 'react';
 import Godkjenning from './Godkjenning/Godkjenning';
 import './GodkjenningSteg.less';
-import KontaktpersonRefusjonOppsumering from '@/AvtaleSide/steg/GodkjenningSteg/Oppsummering/KontaktpersonRefusjonOppsummering/KontaktpersonRefusjonOppsummering';
 
 interface Props {
     oppsummering: FunctionComponent<{ avtaleinnhold: Avtaleinnhold }>;
@@ -36,11 +35,6 @@ const GodkjenningSteg: React.FunctionComponent<Props> = (props) => {
                     </SkjemaTittel>
                     {avtale.avtaleInngått && <LagreSomPdfKnapp avtaleId={avtale.id} />}
                 </div>
-                {avtale.gjeldendeInnhold.refusjonKontaktperson && (
-                    <KontaktpersonRefusjonOppsumering
-                        kontaktpersonRefusjon={avtale.gjeldendeInnhold.refusjonKontaktperson}
-                    />
-                )}
                 {createElement(props.oppsummering, { avtaleinnhold: avtale.gjeldendeInnhold })}
             </Innholdsboks>
 

--- a/src/AvtaleSide/steg/GodkjenningSteg/Oppsummering/Avtaleparter/Avtaleparter.tsx
+++ b/src/AvtaleSide/steg/GodkjenningSteg/Oppsummering/Avtaleparter/Avtaleparter.tsx
@@ -6,6 +6,8 @@ import Stegoppsummering from '../Stegoppsummering/Stegoppsummering';
 import './Avtaleparter.less';
 import AvtaleparterHeaderIkon from './AvtalepartnerHeaderIkon';
 import {InnloggetBrukerContext} from "@/InnloggingBoundary/InnloggingBoundary";
+import KontaktpersonRefusjonOppsumering
+    from "@/AvtaleSide/steg/GodkjenningSteg/Oppsummering/KontaktpersonRefusjonOppsummering/KontaktpersonRefusjonOppsummering";
 
 interface Props {
     avtaleinnhold: Avtaleinnhold;
@@ -83,6 +85,9 @@ const Avtaleparter: FunctionComponent<Props> = props => {
                     borderFarge="farge-lysblaa"
                     skjulHvaMangler={erLåst}
                 />
+                {avtale.gjeldendeInnhold.refusjonKontaktperson && (
+                    <KontaktpersonRefusjonOppsumering/>
+                )}
             </div>
         </Stegoppsummering>
     );

--- a/src/AvtaleSide/steg/GodkjenningSteg/Oppsummering/KontaktpersonRefusjonOppsummering/KontaktpersonRefusjonOppsummering.tsx
+++ b/src/AvtaleSide/steg/GodkjenningSteg/Oppsummering/KontaktpersonRefusjonOppsummering/KontaktpersonRefusjonOppsummering.tsx
@@ -1,13 +1,8 @@
 import React, { FunctionComponent, useContext } from 'react';
-import { RefusjonKontaktperson } from '@/types/avtale';
 import { AvtaleContext } from '@/AvtaleProvider';
 import { AvtaleinfoFeltSjekk } from '@/AvtaleSide/steg/GodkjenningSteg/Oppsummering/AvtaleinfoFeltSjekk/AvtaleinfoFeltSjekk';
 
-interface Props {
-    kontaktpersonRefusjon: RefusjonKontaktperson;
-}
-
-const KontaktpersonRefusjonOppsumering: FunctionComponent<Props> = ({ kontaktpersonRefusjon }) => {
+const KontaktpersonRefusjonOppsumering: FunctionComponent = () => {
     const avtaleContext = useContext(AvtaleContext);
     const gjeldendeInnhold = avtaleContext.avtale.gjeldendeInnhold;
 

--- a/src/AvtaleSide/steg/GodkjenningSteg/Oppsummering/OppsummeringArbeidstrening/OppsummeringArbeidstrening.tsx
+++ b/src/AvtaleSide/steg/GodkjenningSteg/Oppsummering/OppsummeringArbeidstrening/OppsummeringArbeidstrening.tsx
@@ -12,18 +12,16 @@ interface Props {
     avtaleinnhold: Avtaleinnhold;
 }
 
-const OppsummeringArbeidstrening: FunctionComponent<Props> = props => {
-    return (
-        <>
-            <DeltakerInfo oppsummeringside={true} />
-            <Avtaleparter avtaleinnhold={props.avtaleinnhold} />
-            <MaalOppsummering {...props.avtaleinnhold} />
-            <StillingsOppsummering {...props.avtaleinnhold} />
-            <VarighetOppsummering {...props.avtaleinnhold} />
-            <OppfolgingOppsummering {...props.avtaleinnhold} />
-            <Tilrettelegging {...props.avtaleinnhold} />
-        </>
-    );
-};
+const OppsummeringArbeidstrening: FunctionComponent<Props> = props => (
+    <>
+        <DeltakerInfo oppsummeringside={true} />
+        <Avtaleparter avtaleinnhold={props.avtaleinnhold} />
+        <MaalOppsummering {...props.avtaleinnhold} />
+        <StillingsOppsummering {...props.avtaleinnhold} />
+        <VarighetOppsummering {...props.avtaleinnhold} />
+        <OppfolgingOppsummering {...props.avtaleinnhold} />
+        <Tilrettelegging {...props.avtaleinnhold} />
+    </>
+);
 
 export default OppsummeringArbeidstrening;

--- a/src/AvtaleSide/steg/GodkjenningSteg/Oppsummering/OppsummeringMentor/OppsummeringMentor.tsx
+++ b/src/AvtaleSide/steg/GodkjenningSteg/Oppsummering/OppsummeringMentor/OppsummeringMentor.tsx
@@ -24,8 +24,6 @@ const OppsummeringMentor: FunctionComponent<Props> = (props) => (
         <StartOgSluttdatoOppsummering {...props.avtaleinnhold} />
         <OppfolgingOppsummering {...props.avtaleinnhold} />
         <Tilrettelegging {...props.avtaleinnhold} />
-
-
     </>
 );
 


### PR DESCRIPTION
…r. Fordi den hører mer hjemme der enn på toppen av siden.

![Screenshot 2022-11-15 at 13 41 46](https://user-images.githubusercontent.com/67961718/201925121-4dddacea-e7a6-45ba-a022-2a009207b0b4.png)
(Bilde: høyre har kontaktperson for refusjon, venstre har IKKE  kontaktperson for refusjon)

Om dere har andre forslag til hvor den kan plasseres er jeg veldig åpen for forslag :)