### PR TITLE
Arena ryddeavtale

### DIFF
--- a/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtaleVeileder.tsx
+++ b/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtaleVeileder.tsx
@@ -1,13 +1,21 @@
 import TilbakeTilOversiktLenke from '@/AvtaleSide/TilbakeTilOversiktLenke/TilbakeTilOversiktLenke';
+import { AlleredeOpprettetAvtaleContext } from '@/komponenter/alleredeOpprettetTiltak/api/AlleredeOpprettetAvtaleProvider';
+import OpprettAvtaleMedAlleredeOpprettetTiltak from '@/komponenter/alleredeOpprettetTiltak/OpprettAvtaleMedAlleredeOpprettetTiltak';
 import Dokumenttittel from '@/komponenter/Dokumenttittel';
+import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
 import LagreKnapp from '@/komponenter/LagreKnapp/LagreKnapp';
+import VerticalSpacer from '@/komponenter/layout/VerticalSpacer';
 import useValidering from '@/komponenter/useValidering';
+import HvemSkalInngaaAvtalen from '@/OpprettAvtale/OpprettAvtaleVeileder/HvemSkalInngaaAvtalen';
+import InformasjonsboksTopVeilederOppretterAvtale from '@/OpprettAvtale/OpprettAvtaleVeileder/InformasjonsboksTopVeilederOppretterAvtale';
+import TiltaksTypeRadioPanel from '@/OpprettAvtale/OpprettAvtaleVeileder/TiltaksTypeRadioPanel';
 import { pathTilOpprettAvtaleFullfortVeileder } from '@/paths';
 import {
     hentBedriftBrreg,
     opprettAvtaleSomVeileder,
     opprettMentorAvtale,
     sjekkOmDeltakerAlleredeErRegistrertPaaTiltak,
+    sjekkOmVilBliPilot
 } from '@/services/rest-service';
 import { AlleredeRegistrertAvtale, TiltaksType } from '@/types/avtale';
 import { Feilkode, Feilmeldinger } from '@/types/feilkode';
@@ -16,16 +24,11 @@ import { handterFeil } from '@/utils/apiFeilUtils';
 import BEMHelper from '@/utils/bem';
 import { validatorer, validerFnr } from '@/utils/fnrUtils';
 import { validerOrgnr } from '@/utils/orgnrUtils';
-import { Heading } from '@navikt/ds-react';
-import React, { ChangeEvent, FunctionComponent, useContext, useEffect, useState } from 'react';
+import { Heading, Radio, RadioGroup } from '@navikt/ds-react';
+import { ChangeEvent, FunctionComponent, useContext, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import TiltaksTypeRadioPanel from '@/OpprettAvtale/OpprettAvtaleVeileder/TiltaksTypeRadioPanel';
-import InformasjonsboksTopVeilederOppretterAvtale from '@/OpprettAvtale/OpprettAvtaleVeileder/InformasjonsboksTopVeilederOppretterAvtale';
-import HvemSkalInngaaAvtalen from '@/OpprettAvtale/OpprettAvtaleVeileder/HvemSkalInngaaAvtalen';
-import './opprettAvtaleVeileder.less';
 import './OpprettAvtale.less';
-import OpprettAvtaleMedAlleredeOpprettetTiltak from '@/komponenter/alleredeOpprettetTiltak/OpprettAvtaleMedAlleredeOpprettetTiltak';
-import { AlleredeOpprettetAvtaleContext } from '@/komponenter/alleredeOpprettetTiltak/api/AlleredeOpprettetAvtaleProvider';
+import './opprettAvtaleVeileder.less';
 
 const cls = BEMHelper('opprett-avtale');
 
@@ -46,6 +49,8 @@ const OpprettAvtaleVeileder: FunctionComponent = (props) => {
     const [valgtTiltaksType, setTiltaksType] = useState<TiltaksType | undefined>();
     const [modalIsOpen, setModalIsOpen] = useState<boolean>(false);
     const { alleredeRegistrertAvtale, setAlleredeRegistrertAvtale } = useContext(AlleredeOpprettetAvtaleContext);
+    const [kvalifisererTilPilot, setKvalifisererTilPilot] = useState(false);
+    const [valgtPilotEllerArenaAvtale, setValgtPilotEllerArenaAvtale] = useState();
 
     const history = useHistory();
 
@@ -133,7 +138,7 @@ const OpprettAvtaleVeileder: FunctionComponent = (props) => {
                 }
                 return;
             }
-            const avtale = await opprettAvtaleSomVeileder(deltakerFnr, bedriftNr, valgtTiltaksType);
+            const avtale = await opprettAvtaleSomVeileder(deltakerFnr, bedriftNr, valgtTiltaksType, valgtPilotEllerArenaAvtale);
             amplitude.logEvent('#tiltak-avtale-opprettet', { tiltakstype: valgtTiltaksType });
             history.push(pathTilOpprettAvtaleFullfortVeileder(avtale.id));
             return;
@@ -162,11 +167,21 @@ const OpprettAvtaleVeileder: FunctionComponent = (props) => {
         }
     };
 
+    const sjekkOmVilBliPilotAvtale = async () => {
+        if (deltakerFnr.length === 11 && bedriftNr.length === 9 && valgtTiltaksType) {
+            const vilBliPilot = await sjekkOmVilBliPilot(deltakerFnr, bedriftNr, valgtTiltaksType);
+            setKvalifisererTilPilot(vilBliPilot);
+        }
+    }
+
     useEffect(() => {
         sjekkOmAvtaleErOpprettet();
+        sjekkOmVilBliPilotAvtale();
         // eslint-disable-next-line
     }, [valgtTiltaksType, deltakerFnr, bedriftNr]);
 
+    const kvalifisererTilPilotMenIkkeValgtType = kvalifisererTilPilot && valgtPilotEllerArenaAvtale === undefined;
+    
     return (
         <div className={cls.className}>
             <Dokumenttittel tittel="Opprett avtale" />
@@ -201,8 +216,20 @@ const OpprettAvtaleVeileder: FunctionComponent = (props) => {
                 alleredeRegistrertAvtale={alleredeRegistrertAvtale}
                 setModalIsOpen={setModalIsOpen}
             />
+            {kvalifisererTilPilot && (
+                <div>
+                    <VerticalSpacer rem={1} />
+                    <Innholdsboks>
+                        <RadioGroup legend="Skal avtalen være en pilotavtale eller har den fantes i Arena fra før?" onChange={(val) => setValgtPilotEllerArenaAvtale(val)}>
+                            <Radio value="PILOT">Pilotavtale</Radio>
+                            <Radio value="ARENARYDDING">Arena rydding</Radio>
+                        </RadioGroup>
+                    </Innholdsboks>
+                </div>
+            )}
             <div className={cls.element('knappRad')}>
                 <LagreKnapp
+                    disabled={kvalifisererTilPilotMenIkkeValgtType}
                     lagre={opprettAvtaleKlikk}
                     setFeilmelding={setFeilmelding}
                     label={'Opprett avtale'}

--- a/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtaleVeileder.tsx
+++ b/src/OpprettAvtale/OpprettAvtaleVeileder/OpprettAvtaleVeileder.tsx
@@ -24,7 +24,7 @@ import { handterFeil } from '@/utils/apiFeilUtils';
 import BEMHelper from '@/utils/bem';
 import { validatorer, validerFnr } from '@/utils/fnrUtils';
 import { validerOrgnr } from '@/utils/orgnrUtils';
-import { Heading, Radio, RadioGroup } from '@navikt/ds-react';
+import { Alert, Heading, Radio, RadioGroup } from '@navikt/ds-react';
 import { ChangeEvent, FunctionComponent, useContext, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import './OpprettAvtale.less';
@@ -220,9 +220,21 @@ const OpprettAvtaleVeileder: FunctionComponent = (props) => {
                 <div>
                     <VerticalSpacer rem={1} />
                     <Innholdsboks>
-                        <RadioGroup legend="Skal avtalen være en pilotavtale eller har den fantes i Arena fra før?" onChange={(val) => setValgtPilotEllerArenaAvtale(val)}>
+                        <Alert variant="info">
+                            <Heading spacing size="small" level="3">
+                                Avtalen kvalifiserer til pilot
+                            </Heading>
+                            Dette vil si en at det vil bli holdt av penger og opprettet refusjoner i ny
+                            refusjonsløsning. Hvis denne avtalen er en avtale som tidligere har eksistert i Arena, må du
+                            velge Arenarydding, slik at det ikke blir laget nye tilsagn på allerde utbetalte midler.
+                        </Alert>
+                        <VerticalSpacer rem={1} />
+                        <RadioGroup
+                            legend="Skal avtalen være en pilotavtale eller skal den ryddes og overføres fra Arena?"
+                            onChange={(val) => setValgtPilotEllerArenaAvtale(val)}
+                        >
                             <Radio value="PILOT">Pilotavtale</Radio>
-                            <Radio value="ARENARYDDING">Arena rydding</Radio>
+                            <Radio value="ARENARYDDING">Arenarydding</Radio>
                         </RadioGroup>
                     </Innholdsboks>
                 </div>

--- a/src/services/rest-service.ts
+++ b/src/services/rest-service.ts
@@ -20,7 +20,7 @@ import {
     MentorInnhold,
     Stilling,
     TiltaksType,
-    Varighet,
+    Varighet
 } from '@/types/avtale';
 import { ApiError, AutentiseringError, FeilkodeError } from '@/types/errors';
 import { Hendelse } from '@/types/hendelse';
@@ -148,9 +148,10 @@ export const lagreAvtaleDryRun = async (avtale: Avtale): Promise<Avtale> => {
 export const opprettAvtaleSomVeileder = async (
     deltakerFnr: string,
     bedriftNr: string,
-    tiltakstype: TiltaksType
+    tiltakstype: TiltaksType,
+    pilotType?: 'PILOT' | 'ARENARYDDING'
 ): Promise<Avtale> => {
-    return opprettAvtalen('/avtaler', deltakerFnr, bedriftNr, tiltakstype);
+    return opprettAvtalen('/avtaler', deltakerFnr, bedriftNr, tiltakstype, pilotType);
 };
 
 export const opprettAvtaleSomArbeidsgiver = async (
@@ -183,15 +184,27 @@ const opprettAvtalen = async (
     url: string,
     deltakerFnr: string,
     bedriftNr: string,
-    tiltakstype: TiltaksType
+    tiltakstype: TiltaksType,
+    pilotType?: 'PILOT' | 'ARENARYDDING'
 ): Promise<Avtale> => {
-    const postResponse = await api.post(`${url}`, {
+    const pilotParam = {pilotType};
+    const queryParam = new URLSearchParams(removeEmpty(pilotParam));
+    const postResponse = await api.post(`${url}?${queryParam}`, {
         deltakerFnr,
         bedriftNr,
-        tiltakstype,
+        tiltakstype
     });
     const getResponse = await api.get<Avtale>(`${postResponse.headers.location}`);
     return getResponse.data;
+};
+
+export const sjekkOmVilBliPilot = async (
+    deltakerFnr: string,
+    bedriftNr: string,
+    tiltakstype: TiltaksType
+): Promise<boolean> => {
+    const response = await api.post<boolean>(`/avtaler/sjekk-om-vil-bli-pilot`, { deltakerFnr, bedriftNr, tiltakstype });
+    return response.data;
 };
 
 export const mentorGodkjennTaushetserklæring = async (avtale: Avtale): Promise<Avtale> => {


### PR DESCRIPTION
Funksjonalitet for å merke en lønnstilskuddavtale som Arena ryddeavtale slik at det ikke genereres tilskuddsperioder på denne uansett om den er pilot eller ikke.


backend: https://github.com/navikt/tiltaksgjennomforing-api/pull/1031