### PR TITLE
Varsel om å overta avtalen og skrive riktig kontakt informasjon for kun veiledere.

### DIFF
--- a/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
+++ b/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
@@ -16,7 +16,7 @@ const VeilederinfoDel = () => {
         <>
             <div className={cls.element('container')}>
                 <SkjemaTittel>Kontaktperson i NAV</SkjemaTittel>
-                <SkjemaTittel>Veileder navn: {navn}</SkjemaTittel>
+                {navn && <SkjemaTittel>Veileder navn: {navn}</SkjemaTittel>}
                 <div className={cls.element('rad')}>
                     <PakrevdInput
                         label="Fornavn"

--- a/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
+++ b/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
@@ -16,7 +16,7 @@ const VeilederinfoDel = () => {
         <>
             <div className={cls.element('container')}>
                 <SkjemaTittel>Kontaktperson i NAV</SkjemaTittel>
-                {navn && <SkjemaTittel>Veileder navn: {navn}</SkjemaTittel>}
+                {navn?.trim().length !== 0 && <SkjemaTittel>Veileder navn: {navn}</SkjemaTittel>}
                 <div className={cls.element('rad')}>
                     <PakrevdInput
                         label="Fornavn"

--- a/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
+++ b/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
@@ -10,13 +10,15 @@ import { InnloggetBrukerContext } from '@/InnloggingBoundary/InnloggingBoundary'
 const VeilederinfoDel = () => {
     const cls = BEMHelper('kontaktinfo');
     const avtaleContext = useContext(AvtaleContext);
-    const { navn } = useContext(InnloggetBrukerContext);
+    const { navn, rolle } = useContext(InnloggetBrukerContext);
 
     return (
         <>
             <div className={cls.element('container')}>
                 <SkjemaTittel>Kontaktperson i NAV</SkjemaTittel>
-                {navn && navn.trim().length !== 0 && <SkjemaTittel>Veileder navn: {navn}</SkjemaTittel>}
+                {rolle === 'VEILEDER' && navn?.trim().length !== 0 && (
+                    <SkjemaTittel>Veileder navn: {navn}</SkjemaTittel>
+                )}
                 <div className={cls.element('rad')}>
                     <PakrevdInput
                         label="Fornavn"

--- a/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
+++ b/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
@@ -5,15 +5,18 @@ import PakrevdInput from '@/komponenter/PakrevdInput/PakrevdInput';
 import TelefonnummerInput from '@/komponenter/TelefonnummerInput/TelefonnummerInput';
 import BEMHelper from '@/utils/bem';
 import React, { useContext } from 'react';
+import { InnloggetBrukerContext } from '@/InnloggingBoundary/InnloggingBoundary';
 
 const VeilederinfoDel = () => {
     const cls = BEMHelper('kontaktinfo');
     const avtaleContext = useContext(AvtaleContext);
+    const { navn } = useContext(InnloggetBrukerContext);
 
     return (
         <>
             <div className={cls.element('container')}>
                 <SkjemaTittel>Kontaktperson i NAV</SkjemaTittel>
+                <SkjemaTittel>Veileder navn: {navn}</SkjemaTittel>
                 <div className={cls.element('rad')}>
                     <PakrevdInput
                         label="Fornavn"

--- a/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
+++ b/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
@@ -6,37 +6,62 @@ import TelefonnummerInput from '@/komponenter/TelefonnummerInput/TelefonnummerIn
 import BEMHelper from '@/utils/bem';
 import React, { useContext } from 'react';
 import { InnloggetBrukerContext } from '@/InnloggingBoundary/InnloggingBoundary';
+import { Alert } from '@navikt/ds-react';
 
 const VeilederinfoDel = () => {
     const cls = BEMHelper('kontaktinfo');
-    const avtaleContext = useContext(AvtaleContext);
-    const { navn, rolle } = useContext(InnloggetBrukerContext);
+    const { avtale, settAvtaleInnholdVerdi } = useContext(AvtaleContext);
+    const { navn, rolle, identifikator } = useContext(InnloggetBrukerContext);
 
     return (
         <>
             <div className={cls.element('container')}>
                 <SkjemaTittel>Kontaktperson i NAV</SkjemaTittel>
-                {rolle === 'VEILEDER' && navn?.trim().length !== 0 && (
-                    <SkjemaTittel>Veileder navn: {navn}</SkjemaTittel>
+                {rolle === 'VEILEDER' && (
+                    <>
+                        {avtale.veilederNavIdent && avtale.veilederNavIdent === identifikator && (
+                            <p>
+                                Eier av avtalen er{' '}
+                                <b>
+                                    <u>{identifikator}</u>
+                                </b>
+                                .
+                            </p>
+                        )}
+                        {avtale.veilederNavIdent?.trim().length > 0 && avtale.veilederNavIdent !== identifikator && (
+                            <p>
+                                Eier av avtalen er{' '}
+                                <b>
+                                    <u>{avtale.veilederNavIdent}</u>
+                                </b>
+                                .
+                            </p>
+                        )}
+                        {!avtale.veilederNavIdent && <Alert variant={'warning'}>Det er ingen eier av avtalen.</Alert>}
+                        <p>
+                            For å overta avtalen må du eller en ny veileder gå til menyen og velge "Overta avtale" i
+                            tillegg til å skrive inn navn og telefonnummer her.
+                        </p>
+                    </>
                 )}
                 <div className={cls.element('rad')}>
                     <PakrevdInput
                         label="Fornavn"
-                        verdi={avtaleContext.avtale.gjeldendeInnhold.veilederFornavn}
-                        settVerdi={(verdi) => avtaleContext.settAvtaleInnholdVerdi('veilederFornavn', verdi)}
+                        verdi={avtale.gjeldendeInnhold.veilederFornavn}
+                        settVerdi={(verdi) => settAvtaleInnholdVerdi('veilederFornavn', verdi)}
                     />
                     <PakrevdInput
                         label="Etternavn"
-                        verdi={avtaleContext.avtale.gjeldendeInnhold.veilederEtternavn}
-                        settVerdi={(verdi) => avtaleContext.settAvtaleInnholdVerdi('veilederEtternavn', verdi)}
+                        verdi={avtale.gjeldendeInnhold.veilederEtternavn}
+                        settVerdi={(verdi) => settAvtaleInnholdVerdi('veilederEtternavn', verdi)}
                     />
                 </div>
                 <VerticalSpacer rem={1} />
                 <div className={cls.element('rad')}>
                     <TelefonnummerInput
                         label="Mobilnummer"
-                        verdi={avtaleContext.avtale.gjeldendeInnhold.veilederTlf}
-                        settVerdi={(verdi) => avtaleContext.settAvtaleInnholdVerdi('veilederTlf', verdi)}
+                        verdi={avtale.gjeldendeInnhold.veilederTlf}
+                        settVerdi={(verdi) => settAvtaleInnholdVerdi('veilederTlf', verdi)}
                     />
                 </div>
             </div>

--- a/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
+++ b/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
@@ -16,7 +16,7 @@ const VeilederinfoDel = () => {
         <>
             <div className={cls.element('container')}>
                 <SkjemaTittel>Kontaktperson i NAV</SkjemaTittel>
-                {navn?.trim().length !== 0 && <SkjemaTittel>Veileder navn: {navn}</SkjemaTittel>}
+                {navn && navn.trim().length !== 0 && <SkjemaTittel>Veileder navn: {navn}</SkjemaTittel>}
                 <div className={cls.element('rad')}>
                     <PakrevdInput
                         label="Fornavn"

--- a/src/InnloggingBoundary/InnloggingBoundary.tsx
+++ b/src/InnloggingBoundary/InnloggingBoundary.tsx
@@ -21,6 +21,7 @@ const InternflateDecorator = NAVSPA.importer<DecoratorProps>('internarbeidsflate
 export const InnloggetBrukerContext = React.createContext<InnloggetBruker>({
     identifikator: '',
     erNavAnsatt: false,
+    navn: '',
     altinnOrganisasjoner: [],
     rolle: 'INGEN_ROLLE',
     tilganger: {},

--- a/src/types/innlogget-bruker.ts
+++ b/src/types/innlogget-bruker.ts
@@ -19,6 +19,7 @@ export type Rolle = 'DELTAKER' | 'ARBEIDSGIVER' | 'VEILEDER' | 'MENTOR' | 'BESLU
 export interface InnloggetBruker {
     identifikator: string;
     erNavAnsatt: boolean;
+    navn?: string;
     altinnOrganisasjoner: AltinnOrganisasjon[];
     rolle: Rolle;
     tilganger: Tilganger;

--- a/src/types/innlogget-bruker.ts
+++ b/src/types/innlogget-bruker.ts
@@ -19,7 +19,7 @@ export type Rolle = 'DELTAKER' | 'ARBEIDSGIVER' | 'VEILEDER' | 'MENTOR' | 'BESLU
 export interface InnloggetBruker {
     identifikator: string;
     erNavAnsatt: boolean;
-    navn?: string;
+    navn?: string; // veileder navn
     altinnOrganisasjoner: AltinnOrganisasjon[];
     rolle: Rolle;
     tilganger: Tilganger;

--- a/vite.middleware.ts
+++ b/vite.middleware.ts
@@ -62,7 +62,8 @@ export default () => ({
 
         middlewares.use('/tiltaksgjennomforing/fakelogin/aad', async (req, res) => {
             const navIdent = req.headers['navident'] || 'Z123456';
-            const url = `https://tiltak-fakelogin.ekstern.dev.nav.no/token?iss=aad&aud=fake-aad&NAVident=${navIdent}`;
+            const name: string = 'Simonsen,Simon';
+            const url = `https://tiltak-fakelogin.ekstern.dev.nav.no/token?iss=aad&aud=fake-aad&NAVident=${navIdent}&name=${name}`;
             const response = await axios.get(url);
 
             res.setHeader('set-cookie', `fake-aad-idtoken=${response.data};path=/`);


### PR DESCRIPTION
Det er problematisk i de tilfeller hvor ny veileder bare endrer navnet til veileder på avtalen, men faktisk ikke overtar Avtalen. 

Vi trenger å vise ulike meldinger basert på eier av Avtalen. Vi viser en melding til veilederen hvis Avtalen ikke er tilknyttet til de. Om Avtalen ikke er tilknyttet til de, vises det en melding som informerer veileder om å trykke på Overta avtale fra menyen og skriv riktig kontakt info. Meldingene ligger i avtalen under kontakt informasjon.