### PR TITLE
Leser bedriftsnummer fra URL og filtrerer avtale oversikt med oppgitt…

### DIFF
--- a/src/AvtaleOversikt/Filtrering/FiltreringProvider.tsx
+++ b/src/AvtaleOversikt/Filtrering/FiltreringProvider.tsx
@@ -38,6 +38,12 @@ export const FiltreringProvider: FunctionComponent<PropsWithChildren> = (props) 
         if (innloggetBruker.rolle === 'BESLUTTER') return;
         if (innloggetBruker.rolle === 'ARBEIDSGIVER' && !filtre.bedriftNr) return;
 
+        const bedriftNr = filtre.bedriftNr
+            ? filtre.bedriftNr
+            : searchParams.get('bedrift') || searchParams.get('bedriftNr')
+              ? searchParams.get('bedrift') || searchParams.get('bedriftNr')
+              : null;
+        const bedriftNrISøkekriterier = bedriftNr && bedriftNr.trim().length === 9 ? { bedriftNr: bedriftNr } : {};
         const tekniskPage = searchParams.get('page') ? parseInt(searchParams.get('page')!, 10) - 1 : 0;
         let resultat;
         setNettressursCtx({ status: Status.LasterInn });
@@ -50,7 +56,12 @@ export const FiltreringProvider: FunctionComponent<PropsWithChildren> = (props) 
             erGet = true;
         } else {
             resultat = hentAvtalerForInnloggetBrukerMedPost(
-                { sorteringOrder: sorteringOrder, sorteringskolonne: sorteringskolonne, ...filtre },
+                {
+                    sorteringOrder: sorteringOrder,
+                    sorteringskolonne: sorteringskolonne,
+                    ...filtre,
+                    ...bedriftNrISøkekriterier,
+                },
                 10,
                 0,
             );

--- a/src/AvtaleOversikt/Filtrering/FiltreringProvider.tsx
+++ b/src/AvtaleOversikt/Filtrering/FiltreringProvider.tsx
@@ -38,11 +38,7 @@ export const FiltreringProvider: FunctionComponent<PropsWithChildren> = (props) 
         if (innloggetBruker.rolle === 'BESLUTTER') return;
         if (innloggetBruker.rolle === 'ARBEIDSGIVER' && !filtre.bedriftNr) return;
 
-        const bedriftNr = filtre.bedriftNr
-            ? filtre.bedriftNr
-            : searchParams.get('bedrift') || searchParams.get('bedriftNr')
-              ? searchParams.get('bedrift') || searchParams.get('bedriftNr')
-              : null;
+        const bedriftNr = filtre.bedriftNr || searchParams.get('bedrift') || searchParams.get('bedriftNr') || null;
         const bedriftNrISøkekriterier = bedriftNr && bedriftNr.trim().length === 9 ? { bedriftNr: bedriftNr } : {};
         const tekniskPage = searchParams.get('page') ? parseInt(searchParams.get('page')!, 10) - 1 : 0;
         let resultat;


### PR DESCRIPTION
Salesforce lenker tydeligvis til oss for interne veieldere med ?bedriftNr= da de jobber i en kontekst av en bedrift.
Etter at vi gjorde om queryparametere i urlen til en hash/sokId så fungerer ikke det lenger. Bør kanskje ta en titt på om dette
https://nav-it.slack.com/archives/CCM9QUY3U/p1710499979055529