### PR TITLE
Fiks navnekollisjon på image

### DIFF
--- a/.github/workflows/bygg-og-deploy-storybook.yml
+++ b/.github/workflows/bygg-og-deploy-storybook.yml
@@ -31,7 +31,7 @@ jobs:
         id: docker-build-push
         with:
           team: arbeidsgiver
-          tag: tiltaksgjennomforing-storybook
+          image_suffix: storybook
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           dockerfile: StorybookDockerfile

--- a/.github/workflows/bygg-og-deploy-storybook.yml
+++ b/.github/workflows/bygg-og-deploy-storybook.yml
@@ -31,6 +31,7 @@ jobs:
         id: docker-build-push
         with:
           team: arbeidsgiver
+          tag: tiltaksgjennomforing-storybook
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           dockerfile: StorybookDockerfile


### PR DESCRIPTION
Når vi pusher både storybook-appen og tiltaksgjennomforing
fra samme "commit hash", vil byggestegene for tiltaksgjennomforing
og storybook produsere image med nøyaktig samme navn.

Dermed vil samme applikasjon deployes på begge ingresser, og
hvilken app som deployes avhenger av hvilket byggesteg som er
raskest.

Dette fikser vi ved å legge til et "suffiks" i workflowen.