### PR TITLE
Mer granulerte "venter på X"-statuser

### DIFF
--- a/src/AvtaleSide/AvtaleStatus/ArbeidsgiverAvtaleStatus.tsx
+++ b/src/AvtaleSide/AvtaleStatus/ArbeidsgiverAvtaleStatus.tsx
@@ -69,29 +69,20 @@ const ArbeidsgiverAvtaleStatus: FunctionComponent<Props> = ({ avtale }) => {
                     }
                 />
             ) : (
-                <>
-                    {avtale.godkjentAvDeltaker ? (
-                        <StatusPanel
-                            header="Venter på godkjenning av avtalen fra NAV"
-                            body={
-                                <>
-                                    <BodyShort size="small">Du har godkjent.</BodyShort>
-                                    <VerticalSpacer rem={2} />
-                                </>
-                            }
-                        />
-                    ) : (
-                        <StatusPanel
-                            header="Venter på godkjenning av avtalen fra deltaker og NAV"
-                            body={
-                                <>
-                                    <BodyShort size="small">Du har godkjent.</BodyShort>
-                                    <VerticalSpacer rem={2} />
-                                </>
-                            }
-                        />
-                    )}
-                </>
+                <StatusPanel
+                    header={
+                        'Venter på godkjenning av avtalen fra ' +
+                        [!avtale.godkjentAvDeltaker && 'deltaker', !avtale.godkjentAvVeileder && 'NAV']
+                            .filter((x) => x)
+                            .join(' og ')
+                    }
+                    body={
+                        <>
+                            <BodyShort size="small">Du har godkjent.</BodyShort>
+                            <VerticalSpacer rem={2} />
+                        </>
+                    }
+                />
             );
         }
         case 'KLAR_FOR_OPPSTART':

--- a/src/AvtaleSide/AvtaleStatus/DeltakerAvtaleStatus.tsx
+++ b/src/AvtaleSide/AvtaleStatus/DeltakerAvtaleStatus.tsx
@@ -14,7 +14,8 @@ interface Props {
         | 'statusSomEnum'
         | 'annullertTidspunkt'
         | 'godkjentAvDeltaker'
-        | 'godkjentAvDeltaker'
+        | 'godkjentAvArbeidsgiver'
+        | 'godkjentAvVeileder'
         | 'avtaleInngått'
         | 'annullertGrunn'
         | 'avbruttDato'
@@ -64,7 +65,12 @@ const DeltakerAvtaleStatus: FunctionComponent<Props> = ({ avtale }) => {
         case 'MANGLER_GODKJENNING':
             return avtale.godkjentAvDeltaker ? (
                 <StatusPanel
-                    header="Venter på godkjenning av avtalen fra arbeidsgiver og NAV"
+                    header={
+                        'Venter på godkjenning av avtalen fra ' +
+                        [!avtale.godkjentAvArbeidsgiver && 'arbeidsgiver', !avtale.godkjentAvVeileder && 'NAV']
+                            .filter((x) => x)
+                            .join(' og ')
+                    }
                     body={<BodyShort size="small">Du har godkjent avtalen.</BodyShort>}
                 />
             ) : (

--- a/src/stories/AvtaleStatuserArbeidsgiver.mdx
+++ b/src/stories/AvtaleStatuserArbeidsgiver.mdx
@@ -44,16 +44,23 @@ Statusen når arbeidsgiver ikke har godkjent.
 ## MANGLER GODKJENNING
 
 Avtalen er ferdig fylt ut og mangler godkjenninger.
-Avtale er godkjent av arbeidsgiver men mangler godkjenning fra deltaker eller veileder
+Avtale er godkjent av arbeidsgiver men mangler godkjenning fra deltaker
 
-<Story of={ArbeidsgiverAvtaleStatuser.ManglerGodkjenningArbeidsgiverHarGodkjentMenIkkeDeltakerOgNAV} />
+<Story of={ArbeidsgiverAvtaleStatuser.ManglerGodkjenningArbeidsgiverHarGodkjentMenIkkeDeltaker} />
 
 ## MANGLER GODKJENNING
 
 Avtalen er ferdig fylt ut og mangler godkjenninger.
 Avtale er godkjent av arbeidsgiver og deltaker men mangler godkjenning fra veileder
 
-<Story of={ArbeidsgiverAvtaleStatuser.ManglerGodkjenningFraVeilederArbeidsgiverOgDeltakerHarGodkjent} />
+<Story of={ArbeidsgiverAvtaleStatuser.ManglerGodkjenningArbeidsgiverOgDeltakerHarGodkjentMenIkkeVeileder} />
+
+## MANGLER GODKJENNING
+
+Avtalen er ferdig fylt ut og mangler godkjenninger.
+Avtale er godkjent av arbeidsgiver men mangler godkjenning fra deltaker og veileder
+
+<Story of={ArbeidsgiverAvtaleStatuser.ManglerGodkjenningArbeidsgiverHarGodkjentMenIkkeDeltakerOgVeileder} />
 
 ## KLAR FOR OPPSTART
 

--- a/src/stories/AvtaleStatuserArbeidsgiver.stories.tsx
+++ b/src/stories/AvtaleStatuserArbeidsgiver.stories.tsx
@@ -135,30 +135,29 @@ const manglerGodkjenningArbeidsgiverHarGodkjentMenIkkeDeltakerOgNAV = {
     },
 };
 
-export const ManglerGodkjenningArbeidsgiverHarGodkjentMenIkkeDeltakerOgNAV: Story = {
-    name: 'Mangler Godkjenning Arbeidisgiver har godkjent men manger godkjenning av Deltakeren og Veileder',
-    args: { avtale: manglerGodkjenningArbeidsgiverHarGodkjentMenIkkeDeltakerOgNAV },
-};
-
-const manglerGodkjenningFraVeilederArbeidsgiverOgDeltakerHarGodkjent = {
-    erUfordelt: false,
-    statusSomEnum: 'MANGLER_GODKJENNING' as AvtaleStatus,
-    annullertTidspunkt: '',
-    godkjentAvArbeidsgiver: '2024-05-03T12:26:24.40876',
-    godkjentAvDeltaker: '2021-08-01',
-    godkjentAvVeileder: '2021-08-01',
-    avtaleInngått: '',
-    annullertGrunn: 'annulert grunn',
-    avbruttGrunn: 'Begynt i arbeid' as AvbrytelseGrunn,
-    gjeldendeInnhold: {
-        startDato: '2024-05-01',
-        sluttDato: '2025-04-30',
+export const ManglerGodkjenningArbeidsgiverHarGodkjentMenIkkeDeltaker: Story = {
+    name: 'Mangler Godkjenning Arbeidsgiver har godkjent men manger godkjenning av Deltakeren og Veileder',
+    args: {
+        avtale: {
+            ...manglerGodkjenningArbeidsgiverHarGodkjentMenIkkeDeltakerOgNAV,
+            godkjentAvVeileder: '2024-05-03T12:26:24.40876',
+        },
     },
 };
 
-export const ManglerGodkjenningFraVeilederArbeidsgiverOgDeltakerHarGodkjent: Story = {
-    name: 'Mangler Godkjenning Arbeidisgiver har godkjent men manger godkjenning av Deltakeren og Veileder',
-    args: { avtale: manglerGodkjenningFraVeilederArbeidsgiverOgDeltakerHarGodkjent },
+export const ManglerGodkjenningArbeidsgiverOgDeltakerHarGodkjentMenIkkeVeileder: Story = {
+    name: 'Mangler Godkjenning Arbeidsgiver har godkjent men manger godkjenning av Deltakeren og Veileder',
+    args: {
+        avtale: {
+            ...manglerGodkjenningArbeidsgiverHarGodkjentMenIkkeDeltakerOgNAV,
+            godkjentAvDeltaker: '2024-05-03T12:26:24.40876',
+        },
+    },
+};
+
+export const ManglerGodkjenningArbeidsgiverHarGodkjentMenIkkeDeltakerOgVeileder: Story = {
+    name: 'Mangler Godkjenning Arbeidsgiver har godkjent men manger godkjenning av Deltakeren og Veileder',
+    args: { avtale: manglerGodkjenningArbeidsgiverHarGodkjentMenIkkeDeltakerOgNAV },
 };
 
 const klarForOppstart = {

--- a/src/stories/AvtaleStatuserDeltaker.mdx
+++ b/src/stories/AvtaleStatuserDeltaker.mdx
@@ -32,7 +32,19 @@ Dette skjer når en avtale har blitt tilknyttet en veileder
 
 Avtale er godkjent av deltaker men mangler godkjenning fra arbeidsgiver
 
-<Story of={DeltakerAvtaleStatuser.ManglerGodkjenningDeltakerHarGodkjent} />
+<Story of={DeltakerAvtaleStatuser.ManglerGodkjenningDeltakerHarGodkjentMenIkkeArbeidsgiver} />
+
+## MANGLER GODKJENNING
+
+Avtale er godkjent av deltaker men mangler godkjenning fra veileder
+
+<Story of={DeltakerAvtaleStatuser.ManglerGodkjenningDeltakerHarGodkjentMenIkkeVeileder} />
+
+## MANGLER GODKJENNING
+
+Avtale er godkjent av deltaker men mangler godkjenning fra arbeidsgiver og veileder
+
+<Story of={DeltakerAvtaleStatuser.ManglerGodkjenningDeltakerHarGodkjentMenIkkeArbeidsgiverOgVeileder} />
 
 ## MANGLER GODKJENNING
 

--- a/src/stories/AvtaleStatuserDeltaker.stories.tsx
+++ b/src/stories/AvtaleStatuserDeltaker.stories.tsx
@@ -75,6 +75,8 @@ const manglerGodkjenningDeltakerHarGodkjent = {
     statusSomEnum: 'MANGLER_GODKJENNING' as AvtaleStatus,
     annullertTidspunkt: '',
     godkjentAvDeltaker: '2024-05-03T12:26:24.40876',
+    godkjentAvArbeidsgiver: '',
+    godkjentAvVeileder: '',
     avtaleInngått: '',
     annullertGrunn: 'annulert grunn',
     avbruttDato: '2021-08-01',
@@ -85,9 +87,21 @@ const manglerGodkjenningDeltakerHarGodkjent = {
     },
 };
 
-export const ManglerGodkjenningDeltakerHarGodkjent: Story = {
-    name: 'Mangler Godkjenning Deltaker har godkjent men manger godkjenning av Arbeidsgiver og Veileder',
-    args: { avtale: manglerGodkjenningDeltakerHarGodkjent },
+export const ManglerGodkjenningDeltakerHarGodkjentMenIkkeArbeidsgiver: Story = {
+    name: 'Mangler Godkjenning: Deltaker har godkjent men manger godkjenning av Arbeidsgiver',
+    args: { avtale: { ...manglerGodkjenningDeltakerHarGodkjent, godkjentAvVeileder: '2021-08-01' } },
+};
+
+export const ManglerGodkjenningDeltakerHarGodkjentMenIkkeVeileder: Story = {
+    name: 'Mangler Godkjenning: Deltaker har godkjent men manger godkjenning av Veileder',
+    args: { avtale: { ...manglerGodkjenningDeltakerHarGodkjent, godkjentAvArbeidsgiver: '2021-08-01' } },
+};
+
+export const ManglerGodkjenningDeltakerHarGodkjentMenIkkeArbeidsgiverOgVeileder: Story = {
+    name: 'Mangler Godkjenning: Deltaker har godkjent men manger godkjenning av Arbeidsgiver og Veileder',
+    args: {
+        avtale: manglerGodkjenningDeltakerHarGodkjent,
+    },
 };
 
 const manglerGodkjenningDeltakerHarIkkeGodkjent = {


### PR DESCRIPTION
For deltaker og arbeidsgiver er statusen som vises når man venter på at andre parter skal godkjenne
ikke spesifikk på om det er NAV eller deltaker/arbeidsgiver vi faktisk venter på.

Denne endringen gjør at statusen mer tydelig viser om det er deltaker/arbeidsgiver eller NAV man faktisk venter på, eventuelt begge.

# Gammel for arbeidsgiver
<img width="851" alt="bilde" src="https://github.com/navikt/tiltaksgjennomforing/assets/3494925/33881793-179d-44c5-a5a2-6df6b389f852">

# Gammel for deltaker
<img width="851" alt="bilde" src="https://github.com/navikt/tiltaksgjennomforing/assets/3494925/026ff728-d9ab-4959-b5cf-a004d53050ed">

# Ny for arbeidsgiver
<img width="877" alt="bilde" src="https://github.com/navikt/tiltaksgjennomforing/assets/3494925/09c29b76-4fa0-40c3-8de3-05b100bc0a6f">

# Ny for deltaker
<img width="851" alt="bilde" src="https://github.com/navikt/tiltaksgjennomforing/assets/3494925/64f92d29-e48a-4ac1-b570-a8deebcc460c">
