### PR TITLE
Oppdater URL til contextholder

### DIFF
--- a/server/src/proxy/decorator-intern-proxy.ts
+++ b/server/src/proxy/decorator-intern-proxy.ts
@@ -18,7 +18,7 @@ export function setup(app: Express) {
             }
         },
         createProxyMiddleware({
-            target: 'http://modiacontextholder.personoversikt/modiacontextholder',
+            target: 'http://modiacontextholder.personoversikt',
             followRedirects: false,
             changeOrigin: true,
         }),


### PR DESCRIPTION
`/modiacontextholder` base pathen eksisterer kun for kompatibilitet
med gamle ingresser og skal fjernes.
