### PR TITLE
feat. ny modal for aktsomhetskontroll for arbeidsgivere

### DIFF
--- a/src/AvtaleSide/AvtaleKontroll.module.less
+++ b/src/AvtaleSide/AvtaleKontroll.module.less
@@ -1,0 +1,5 @@
+.container {
+    display: flex;
+    justify-content: center;
+    margin-top: 10rem;
+}

--- a/src/AvtaleSide/AvtaleKontroll.tsx
+++ b/src/AvtaleSide/AvtaleKontroll.tsx
@@ -1,0 +1,81 @@
+import React, { FunctionComponent, PropsWithChildren, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { BodyLong, Button, Loader, Modal } from '@navikt/ds-react';
+import { Locked } from '@navikt/ds-icons';
+
+import { Rolle } from '@/types/innlogget-bruker';
+import { useAvtaleKreverAktsomhet } from '@/services/use-rest';
+import { useInnloggetBruker } from '@/InnloggingBoundary/InnloggingBoundary';
+
+import { container } from './AvtaleKontroll.module.less';
+
+const ROLLER_SOM_KREVER_KONTROLL: Rolle[] = ['ARBEIDSGIVER'];
+
+const AvtaleKontroll: FunctionComponent<PropsWithChildren> = (props) => {
+    const { rolle } = useInnloggetBruker();
+    const isKreverKontroll = ROLLER_SOM_KREVER_KONTROLL.includes(rolle);
+
+    const { avtaleId } = useParams<{ avtaleId: string }>();
+    const { isLoading, data: avtaleKreverAktsomhet } = useAvtaleKreverAktsomhet(
+        isKreverKontroll ? avtaleId : undefined,
+    );
+
+    const navigate = useNavigate();
+    const ref = useRef<HTMLDialogElement>(null);
+    const [isGodkjent, setGodkjent] = useState<boolean>(!isKreverKontroll);
+
+    if (isLoading) {
+        return (
+            <div className={container}>
+                <Loader variant="neutral" size="xlarge" />
+            </div>
+        );
+    }
+
+    if (!avtaleKreverAktsomhet || isGodkjent) {
+        return props.children;
+    }
+
+    return (
+        <Modal
+            ref={ref}
+            open={true}
+            header={{
+                icon: <Locked title="Lås" />,
+                heading: 'Deltaker har adressebeskyttelse',
+            }}
+            onClose={() => {
+                navigate(-1);
+            }}
+        >
+            <Modal.Body>
+                <BodyLong>
+                    Denne personen har hemmelig adresse og du må derfor utvise aktsomhet. Du skal kun gjøre oppslag
+                    dersom det er nødvendig for å levere tjenesten til denne personen. Nav logger ditt navn og tidspunkt
+                    for oppslaget.
+                </BodyLong>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    type="button"
+                    onClick={() => {
+                        setGodkjent(true);
+                    }}
+                >
+                    Vis avtale
+                </Button>
+                <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() => {
+                        navigate(-1);
+                    }}
+                >
+                    Avslutt
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default AvtaleKontroll;

--- a/src/AvtaleSide/steg/GodkjenningSteg/Versjonering/VersjoneringKomponent.tsx
+++ b/src/AvtaleSide/steg/GodkjenningSteg/Versjonering/VersjoneringKomponent.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const VersjoneringKomponent = (props: Props) => {
     const { avtale } = props;
-    const versjoner = useHentVersjoner(avtale);
+    const versjoner = useHentVersjoner(!avtale.feilregistrert ? avtale.id : undefined);
 
     if (versjoner.length <= 1) {
         return null;

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -22,6 +22,7 @@ import { VarselOmNedetid } from '@/InnloggingBoundary/VarselOmNedetid';
 import ErrorBoundary from '@/komponenter/ErrorBoundary';
 import AvtaleRouteError from '@/Router/AvtaleRouteError';
 import OversiktRouteError from '@/Router/OversiktRouteError';
+import AvtaleKontroll from '@/AvtaleSide/AvtaleKontroll';
 
 export const basename = '/tiltaksgjennomforing';
 
@@ -92,9 +93,11 @@ const router = createBrowserRouter(
                             path: Path.AVTALE,
                             element: (
                                 <AvtaleProvider>
-                                    <AvtaleFetcher>
-                                        <Outlet />
-                                    </AvtaleFetcher>
+                                    <AvtaleKontroll>
+                                        <AvtaleFetcher>
+                                            <Outlet />
+                                        </AvtaleFetcher>
+                                    </AvtaleKontroll>
                                 </AvtaleProvider>
                             ),
                             errorElement: <AvtaleRouteError />,

--- a/src/services/use-rest.ts
+++ b/src/services/use-rest.ts
@@ -46,11 +46,8 @@ const swrConfig = {
     suspense: true,
 };
 
-export const useHentVersjoner = (avtale: Avtale) => {
-    const { data } = useSWR<AvtaleVersjon[]>(
-        !avtale.feilregistrert ? `/avtaler/${avtale.id}/versjoner` : null,
-        swrConfig,
-    );
+export const useHentVersjoner = (avtaleId?: string) => {
+    const { data } = useSWR<AvtaleVersjon[]>(avtaleId ? `/avtaler/${avtaleId}/versjoner` : undefined, swrConfig);
     return data || [];
 };
 
@@ -59,6 +56,13 @@ export const useHentEnhet = (enhetsnummer?: string) => {
         ...swrConfig,
         suspense: false,
         shouldRetryOnError: false,
+        revalidateOnFocus: false,
+    });
+};
+
+export const useAvtaleKreverAktsomhet = (avtaleId?: string) => {
+    return useSWR<boolean>(avtaleId ? `/avtaler/${avtaleId}/krever-aktsomhet` : undefined, {
+        ...swrConfig,
         revalidateOnFocus: false,
     });
 };


### PR DESCRIPTION
I forbindelse med kode-6 skal vi vise en dialog før vi laster avtalen som informerer arbeidsgivere om å vise aktsomhet ved en person som har adressesperre.