### PR TITLE
fix. bruk bedriftNr som identifikator for arbeidsgivere

### DIFF
--- a/src/services/rest-service.ts
+++ b/src/services/rest-service.ts
@@ -42,6 +42,15 @@ const api = axios.create({
 
 axiosRetry(api, { retries: 3 });
 
+api.interceptors.request.use((config) => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const bedriftNr = searchParams.get('bedrift') || searchParams.get('bedriftNr') || null;
+    if (bedriftNr) {
+        config.headers['bedriftNr'] = bedriftNr;
+    }
+    return config;
+});
+
 api.interceptors.response.use(
     (response) => response,
     (error) => {

--- a/src/services/use-rest.ts
+++ b/src/services/use-rest.ts
@@ -14,6 +14,15 @@ const api = axios.create({
     headers: { Pragma: 'no-cache', 'Cache-Control': 'no-cache', 'Content-Type': 'application/json' },
 });
 
+api.interceptors.request.use((config) => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const bedriftNr = searchParams.get('bedrift') || searchParams.get('bedriftNr') || null;
+    if (bedriftNr) {
+        config.headers['bedriftNr'] = bedriftNr;
+    }
+    return config;
+});
+
 api.interceptors.response.use(
     (response) => response,
     (error) => {


### PR DESCRIPTION
Arbeidsgivere utfører ikke handlering på vegne av seg selv men på vegne av bedriften. Derfor bør identifikatoren på avtaleparten være bedriftnr istedenfor fnr på innlogget bruker.

Denne endringen henter bedriftNr fra header som blir sendt fra frontend via intercepter i Axios på valgt bedrift.

Dette gjør også at vi kan bruke utførtAv som tenkt for arbeidsgivere på lik linje som for deltaker og veileder.