### PR TITLE
Lås tekstfelt for endring av bedriftnavn

### DIFF
--- a/src/AvtaleSide/steg/KontaktInformasjonSteg/ArbeidsgiverinfoDel/ArbeidsgiverinfoDel.tsx
+++ b/src/AvtaleSide/steg/KontaktInformasjonSteg/ArbeidsgiverinfoDel/ArbeidsgiverinfoDel.tsx
@@ -12,43 +12,37 @@ const ArbeidsgiverinfoDel = () => {
     const { avtale, settAvtaleInnholdVerdi: settAvtaleVerdi } = useContext(AvtaleContext);
 
     return (
-        <>
-            <div className={cls.element('container')}>
-                <SkjemaTittel>Informasjon om arbeidsgiveren</SkjemaTittel>
-                <Fieldset legend="" title="Om bedriften" className={cls.element('skjemagruppe')}>
-                    <div className={cls.element('rad')}>
-                        <PakrevdInput
-                            label="Bedriftens navn"
-                            verdi={avtale.gjeldendeInnhold.bedriftNavn}
-                            settVerdi={(verdi) => settAvtaleVerdi('bedriftNavn', verdi)}
-                        />
-                        <VisueltDisabledInputFelt label="Virksomhetsnummer" tekst={avtale.bedriftNr} />
-                    </div>
-                </Fieldset>
-                <Fieldset legend="" title="Kontaktperson for avtalen" className={cls.element('skjemagruppe')}>
-                    <div className={cls.element('rad')}>
-                        <PakrevdInput
-                            label="Fornavn"
-                            verdi={avtale.gjeldendeInnhold.arbeidsgiverFornavn}
-                            settVerdi={(verdi) => settAvtaleVerdi('arbeidsgiverFornavn', verdi)}
-                        />
-                        <PakrevdInput
-                            label="Etternavn"
-                            verdi={avtale.gjeldendeInnhold.arbeidsgiverEtternavn}
-                            settVerdi={(verdi) => settAvtaleVerdi('arbeidsgiverEtternavn', verdi)}
-                        />
-                    </div>
+        <div className={cls.element('container')}>
+            <SkjemaTittel>Informasjon om arbeidsgiveren</SkjemaTittel>
+            <Fieldset legend="" title="Om bedriften" className={cls.element('skjemagruppe')}>
+                <div className={cls.element('rad')}>
+                    <VisueltDisabledInputFelt label="Bedriftens navn" tekst={avtale.gjeldendeInnhold.bedriftNavn} />
+                    <VisueltDisabledInputFelt label="Virksomhetsnummer" tekst={avtale.bedriftNr} />
+                </div>
+            </Fieldset>
+            <Fieldset legend="" title="Kontaktperson for avtalen" className={cls.element('skjemagruppe')}>
+                <div className={cls.element('rad')}>
+                    <PakrevdInput
+                        label="Fornavn"
+                        verdi={avtale.gjeldendeInnhold.arbeidsgiverFornavn}
+                        settVerdi={(verdi) => settAvtaleVerdi('arbeidsgiverFornavn', verdi)}
+                    />
+                    <PakrevdInput
+                        label="Etternavn"
+                        verdi={avtale.gjeldendeInnhold.arbeidsgiverEtternavn}
+                        settVerdi={(verdi) => settAvtaleVerdi('arbeidsgiverEtternavn', verdi)}
+                    />
+                </div>
 
-                    <div className={cls.element('rad')}>
-                        <TelefonnummerInput
-                            label="Mobilnummer"
-                            verdi={avtale.gjeldendeInnhold.arbeidsgiverTlf}
-                            settVerdi={(verdi) => settAvtaleVerdi('arbeidsgiverTlf', verdi)}
-                        />
-                    </div>
-                </Fieldset>
-            </div>
-        </>
+                <div className={cls.element('rad')}>
+                    <TelefonnummerInput
+                        label="Mobilnummer"
+                        verdi={avtale.gjeldendeInnhold.arbeidsgiverTlf}
+                        settVerdi={(verdi) => settAvtaleVerdi('arbeidsgiverTlf', verdi)}
+                    />
+                </div>
+            </Fieldset>
+        </div>
     );
 };
 

--- a/src/AvtaleSide/steg/KontaktInformasjonSteg/ArbeidsgiverinfoDel/Relasjoner.tsx
+++ b/src/AvtaleSide/steg/KontaktInformasjonSteg/ArbeidsgiverinfoDel/Relasjoner.tsx
@@ -62,39 +62,37 @@ const Relasjoner: FunctionComponent<Props> = ({ tiltakstype }: Props) => {
                         {harFamilietilknytningSomJaNeiSvar(harFamilietilknytning)}
                     </div>
                 ) : (
-                    <>
-                        <RadioGroup
-                            legend="Familierelasjoner"
-                            value={avtale.gjeldendeInnhold.harFamilietilknytning}
-                            className={cls.element('familie-relasjoner')}
-                        >
-                            <div className={cls.element('familie-relasjoner-valg')}>
-                                <RadioPanel
-                                    className={cls.element('radioknapp')}
-                                    name="familievalg"
-                                    checked={harFamilietilknytning}
-                                    value={true}
-                                    onChange={() => settAvtaleVerdier({ harFamilietilknytning: true })}
-                                >
-                                    Ja
-                                </RadioPanel>
-                                <RadioPanel
-                                    className={cls.element('radioknapp')}
-                                    name="familievalg"
-                                    checked={harFamilietilknytning === false}
-                                    value={false}
-                                    onChange={() => {
-                                        settAvtaleVerdier({
-                                            familietilknytningForklaring: undefined,
-                                            harFamilietilknytning: false,
-                                        });
-                                    }}
-                                >
-                                    Nei
-                                </RadioPanel>
-                            </div>
-                        </RadioGroup>
-                    </>
+                    <RadioGroup
+                        legend="Familierelasjoner"
+                        value={avtale.gjeldendeInnhold.harFamilietilknytning}
+                        className={cls.element('familie-relasjoner')}
+                    >
+                        <div className={cls.element('familie-relasjoner-valg')}>
+                            <RadioPanel
+                                className={cls.element('radioknapp')}
+                                name="familievalg"
+                                checked={harFamilietilknytning}
+                                value={true}
+                                onChange={() => settAvtaleVerdier({ harFamilietilknytning: true })}
+                            >
+                                Ja
+                            </RadioPanel>
+                            <RadioPanel
+                                className={cls.element('radioknapp')}
+                                name="familievalg"
+                                checked={harFamilietilknytning === false}
+                                value={false}
+                                onChange={() => {
+                                    settAvtaleVerdier({
+                                        familietilknytningForklaring: undefined,
+                                        harFamilietilknytning: false,
+                                    });
+                                }}
+                            >
+                                Nei
+                            </RadioPanel>
+                        </div>
+                    </RadioGroup>
                 )}
             </div>
             {harFamilietilknytning && (
@@ -116,13 +114,11 @@ const Relasjoner: FunctionComponent<Props> = ({ tiltakstype }: Props) => {
             )}
             <>
                 {rolle === 'VEILEDER' && (
-                    <>
-                        <Popover open={!!popoverAnker} anchorEl={popoverAnker} onClose={() => setPopoverAnker(null)}>
-                            <Popover.Content>
-                                <div style={{ padding: '1rem' }}>Dette fylles ut av arbeidsgiver.</div>
-                            </Popover.Content>
-                        </Popover>
-                    </>
+                    <Popover open={!!popoverAnker} anchorEl={popoverAnker} onClose={() => setPopoverAnker(null)}>
+                        <Popover.Content>
+                            <div style={{ padding: '1rem' }}>Dette fylles ut av arbeidsgiver.</div>
+                        </Popover.Content>
+                    </Popover>
                 )}
             </>
         </div>

--- a/src/AvtaleSide/steg/KontaktInformasjonSteg/DeltakerinfoDel/DeltakerinfoDel.tsx
+++ b/src/AvtaleSide/steg/KontaktInformasjonSteg/DeltakerinfoDel/DeltakerinfoDel.tsx
@@ -3,40 +3,38 @@ import SkjemaTittel from '@/komponenter/form/SkjemaTittel';
 import PakrevdInput from '@/komponenter/PakrevdInput/PakrevdInput';
 import TelefonnummerInput from '@/komponenter/TelefonnummerInput/TelefonnummerInput';
 import BEMHelper from '@/utils/bem';
-import React, { FunctionComponent, useContext } from 'react';
+import { FunctionComponent, useContext } from 'react';
 import VisueltDisabledInputFelt from '@/komponenter/VisueltDisabledInputFelt/VisueltDisabledInputFelt';
 
 const DeltakerinfoDel: FunctionComponent = () => {
     const cls = BEMHelper('kontaktinfo');
     const avtaleContext = useContext(AvtaleContext);
     return (
-        <>
-            <div className={cls.element('container')}>
-                <SkjemaTittel>Informasjon om deltakeren</SkjemaTittel>
-                <div className={cls.element('rad')}>
-                    <VisueltDisabledInputFelt label="Fødselsnummer" tekst={avtaleContext.avtale.deltakerFnr} />
-                </div>
-                <div className={cls.element('rad')}>
-                    <PakrevdInput
-                        label="Fornavn"
-                        verdi={avtaleContext.avtale.gjeldendeInnhold.deltakerFornavn}
-                        settVerdi={(verdi) => avtaleContext.settAvtaleInnholdVerdi('deltakerFornavn', verdi)}
-                    />
-                    <PakrevdInput
-                        label="Etternavn"
-                        verdi={avtaleContext.avtale.gjeldendeInnhold.deltakerEtternavn}
-                        settVerdi={(verdi) => avtaleContext.settAvtaleInnholdVerdi('deltakerEtternavn', verdi)}
-                    />
-                </div>
-                <div className={cls.element('rad')}>
-                    <TelefonnummerInput
-                        label="Mobilnummer"
-                        verdi={avtaleContext.avtale.gjeldendeInnhold.deltakerTlf}
-                        settVerdi={(verdi) => avtaleContext.settAvtaleInnholdVerdi('deltakerTlf', verdi)}
-                    />
-                </div>
+        <div className={cls.element('container')}>
+            <SkjemaTittel>Informasjon om deltakeren</SkjemaTittel>
+            <div className={cls.element('rad')}>
+                <VisueltDisabledInputFelt label="Fødselsnummer" tekst={avtaleContext.avtale.deltakerFnr} />
             </div>
-        </>
+            <div className={cls.element('rad')}>
+                <PakrevdInput
+                    label="Fornavn"
+                    verdi={avtaleContext.avtale.gjeldendeInnhold.deltakerFornavn}
+                    settVerdi={(verdi) => avtaleContext.settAvtaleInnholdVerdi('deltakerFornavn', verdi)}
+                />
+                <PakrevdInput
+                    label="Etternavn"
+                    verdi={avtaleContext.avtale.gjeldendeInnhold.deltakerEtternavn}
+                    settVerdi={(verdi) => avtaleContext.settAvtaleInnholdVerdi('deltakerEtternavn', verdi)}
+                />
+            </div>
+            <div className={cls.element('rad')}>
+                <TelefonnummerInput
+                    label="Mobilnummer"
+                    verdi={avtaleContext.avtale.gjeldendeInnhold.deltakerTlf}
+                    settVerdi={(verdi) => avtaleContext.settAvtaleInnholdVerdi('deltakerTlf', verdi)}
+                />
+            </div>
+        </div>
     );
 };
 

--- a/src/AvtaleSide/steg/KontaktInformasjonSteg/FadderinfoDel/FadderinfoDel.tsx
+++ b/src/AvtaleSide/steg/KontaktInformasjonSteg/FadderinfoDel/FadderinfoDel.tsx
@@ -4,9 +4,7 @@ import VerticalSpacer from '@/komponenter/layout/VerticalSpacer';
 import PakrevdInput from '@/komponenter/PakrevdInput/PakrevdInput';
 import TelefonnummerInput from '@/komponenter/TelefonnummerInput/TelefonnummerInput';
 import BEMHelper from '@/utils/bem';
-import React, { useContext } from 'react';
-import { InnloggetBrukerContext } from '@/InnloggingBoundary/InnloggingBoundary';
-import { Alert } from '@navikt/ds-react';
+import { useContext } from 'react';
 
 const FadderinfoDel = () => {
     const cls = BEMHelper('kontaktinfo');
@@ -14,31 +12,29 @@ const FadderinfoDel = () => {
 
     const vtao = avtale.gjeldendeInnhold.vtao;
     return (
-        <>
-            <div className={cls.element('container')}>
-                <SkjemaTittel>Informasjon om fadderen</SkjemaTittel>
-                <div className={cls.element('rad')}>
-                    <PakrevdInput
-                        label="Fornavn"
-                        verdi={avtale.gjeldendeInnhold.vtao?.fadderFornavn}
-                        settVerdi={(verdi) => settAvtaleInnholdVerdi('vtao', { ...vtao, fadderFornavn: verdi })}
-                    />
-                    <PakrevdInput
-                        label="Etternavn"
-                        verdi={avtale.gjeldendeInnhold.vtao?.fadderEtternavn}
-                        settVerdi={(verdi) => settAvtaleInnholdVerdi('vtao', { ...vtao, fadderEtternavn: verdi })}
-                    />
-                </div>
-                <VerticalSpacer rem={1} />
-                <div className={cls.element('rad')}>
-                    <TelefonnummerInput
-                        label="Mobilnummer"
-                        verdi={avtale.gjeldendeInnhold.vtao?.fadderTlf}
-                        settVerdi={(verdi) => settAvtaleInnholdVerdi('vtao', { ...vtao, fadderTlf: verdi })}
-                    />
-                </div>
+        <div className={cls.element('container')}>
+            <SkjemaTittel>Informasjon om fadderen</SkjemaTittel>
+            <div className={cls.element('rad')}>
+                <PakrevdInput
+                    label="Fornavn"
+                    verdi={avtale.gjeldendeInnhold.vtao?.fadderFornavn}
+                    settVerdi={(verdi) => settAvtaleInnholdVerdi('vtao', { ...vtao, fadderFornavn: verdi })}
+                />
+                <PakrevdInput
+                    label="Etternavn"
+                    verdi={avtale.gjeldendeInnhold.vtao?.fadderEtternavn}
+                    settVerdi={(verdi) => settAvtaleInnholdVerdi('vtao', { ...vtao, fadderEtternavn: verdi })}
+                />
             </div>
-        </>
+            <VerticalSpacer rem={1} />
+            <div className={cls.element('rad')}>
+                <TelefonnummerInput
+                    label="Mobilnummer"
+                    verdi={avtale.gjeldendeInnhold.vtao?.fadderTlf}
+                    settVerdi={(verdi) => settAvtaleInnholdVerdi('vtao', { ...vtao, fadderTlf: verdi })}
+                />
+            </div>
+        </div>
     );
 };
 

--- a/src/AvtaleSide/steg/KontaktInformasjonSteg/KontaktpersonRefusjoninfoDel/KontaktpersonRefusjoninfoDel.tsx
+++ b/src/AvtaleSide/steg/KontaktInformasjonSteg/KontaktpersonRefusjoninfoDel/KontaktpersonRefusjoninfoDel.tsx
@@ -56,97 +56,93 @@ const KontaktpersonRefusjoninfoDel = () => {
     }
 
     return (
-        <>
-            <div className={cls.element('container')}>
-                <div className={cls.element('rad', 'header')}>
-                    <SkjemaTittel>Kontaktperson hos arbeidsgiver for refusjon</SkjemaTittel>
-                    <HelpText className={cls.element('helptekst')} title="Hva menes med kontaktperson for refusjon?">
-                        For eksempel en regnskapsfører som skal motta varslinger om refusjon
-                    </HelpText>
-                </div>
-                <Fieldset legend="" title="">
-                    {!visEkstraKontaktpersonFelt && !kontaktpersonAlleredeDefinert && (
-                        <div className={cls.element('buttonSpaceing')}>
-                            <Button
-                                variant="secondary"
-                                onClick={() => {
-                                    setVisEkstraKontaktpersonFelt(!visEkstraKontaktpersonFelt);
-                                    settAvtaleInnholdVerdier({
-                                        ...avtale.gjeldendeInnhold,
-                                        refusjonKontaktperson: {
-                                            refusjonKontaktpersonFornavn: '',
-                                            refusjonKontaktpersonEtternavn: '',
-                                            refusjonKontaktpersonTlf: '',
-                                            ønskerVarslingOmRefusjon: true,
-                                        },
-                                    });
-                                }}
-                            >
-                                + Legg til kontaktperson
-                            </Button>
-                        </div>
-                    )}
-
-                    {(kontaktpersonAlleredeDefinert || visEkstraKontaktpersonFelt) && (
-                        <>
-                            <div className={cls.element('rad')}>
-                                <PakrevdInput
-                                    label="Kontaktperson for refusjon sitt fornavn"
-                                    verdi={avtale.gjeldendeInnhold.refusjonKontaktperson?.refusjonKontaktpersonFornavn}
-                                    settVerdi={(verdi) =>
-                                        settAvtaleInnholdVerdi('refusjonKontaktperson', {
-                                            ...avtale.gjeldendeInnhold.refusjonKontaktperson,
-                                            refusjonKontaktpersonFornavn: verdi ?? '',
-                                        })
-                                    }
-                                />
-                                <PakrevdInput
-                                    label="Kontaktperson for refusjon sitt etternavn"
-                                    verdi={
-                                        avtale.gjeldendeInnhold.refusjonKontaktperson?.refusjonKontaktpersonEtternavn
-                                    }
-                                    settVerdi={(verdi) =>
-                                        settAvtaleInnholdVerdi('refusjonKontaktperson', {
-                                            ...avtale.gjeldendeInnhold.refusjonKontaktperson,
-                                            refusjonKontaktpersonEtternavn: verdi ?? '',
-                                        })
-                                    }
-                                />
-                            </div>
-                            <div className={cls.element('rad')}>
-                                <TelefonnummerInput
-                                    label="Kontaktperson for refusjon sitt mobilnummer"
-                                    verdi={avtale.gjeldendeInnhold.refusjonKontaktperson?.refusjonKontaktpersonTlf}
-                                    settVerdi={(verdi) =>
-                                        settAvtaleInnholdVerdi('refusjonKontaktperson', {
-                                            ...avtale.gjeldendeInnhold.refusjonKontaktperson,
-                                            refusjonKontaktpersonTlf: verdi ?? '',
-                                        })
-                                    }
-                                />
-                            </div>
-                            <div>
-                                <Checkbox
-                                    checked={avtale.gjeldendeInnhold?.refusjonKontaktperson?.ønskerVarslingOmRefusjon}
-                                    onChange={() => sjekkeOmVarslingOmRefusjonKanSkrusAv()}
-                                >
-                                    Arbeidsgiver for avtalen {getArbeidsgivernavn()} ønsker også å motta varslinger om
-                                    refusjon
-                                </Checkbox>
-                            </div>
-                            {feilmelding && (
-                                <Alert variant="warning" style={{ marginBottom: '1rem' }}>
-                                    {feilmelding}
-                                </Alert>
-                            )}
-                            <Button variant="secondary" onClick={() => resetRefusjonKontaktPerson()}>
-                                Fjern kontaktperson
-                            </Button>
-                        </>
-                    )}
-                </Fieldset>
+        <div className={cls.element('container')}>
+            <div className={cls.element('rad', 'header')}>
+                <SkjemaTittel>Kontaktperson hos arbeidsgiver for refusjon</SkjemaTittel>
+                <HelpText className={cls.element('helptekst')} title="Hva menes med kontaktperson for refusjon?">
+                    For eksempel en regnskapsfører som skal motta varslinger om refusjon
+                </HelpText>
             </div>
-        </>
+            <Fieldset legend="" title="">
+                {!visEkstraKontaktpersonFelt && !kontaktpersonAlleredeDefinert && (
+                    <div className={cls.element('buttonSpaceing')}>
+                        <Button
+                            variant="secondary"
+                            onClick={() => {
+                                setVisEkstraKontaktpersonFelt(!visEkstraKontaktpersonFelt);
+                                settAvtaleInnholdVerdier({
+                                    ...avtale.gjeldendeInnhold,
+                                    refusjonKontaktperson: {
+                                        refusjonKontaktpersonFornavn: '',
+                                        refusjonKontaktpersonEtternavn: '',
+                                        refusjonKontaktpersonTlf: '',
+                                        ønskerVarslingOmRefusjon: true,
+                                    },
+                                });
+                            }}
+                        >
+                            + Legg til kontaktperson
+                        </Button>
+                    </div>
+                )}
+
+                {(kontaktpersonAlleredeDefinert || visEkstraKontaktpersonFelt) && (
+                    <>
+                        <div className={cls.element('rad')}>
+                            <PakrevdInput
+                                label="Kontaktperson for refusjon sitt fornavn"
+                                verdi={avtale.gjeldendeInnhold.refusjonKontaktperson?.refusjonKontaktpersonFornavn}
+                                settVerdi={(verdi) =>
+                                    settAvtaleInnholdVerdi('refusjonKontaktperson', {
+                                        ...avtale.gjeldendeInnhold.refusjonKontaktperson,
+                                        refusjonKontaktpersonFornavn: verdi ?? '',
+                                    })
+                                }
+                            />
+                            <PakrevdInput
+                                label="Kontaktperson for refusjon sitt etternavn"
+                                verdi={avtale.gjeldendeInnhold.refusjonKontaktperson?.refusjonKontaktpersonEtternavn}
+                                settVerdi={(verdi) =>
+                                    settAvtaleInnholdVerdi('refusjonKontaktperson', {
+                                        ...avtale.gjeldendeInnhold.refusjonKontaktperson,
+                                        refusjonKontaktpersonEtternavn: verdi ?? '',
+                                    })
+                                }
+                            />
+                        </div>
+                        <div className={cls.element('rad')}>
+                            <TelefonnummerInput
+                                label="Kontaktperson for refusjon sitt mobilnummer"
+                                verdi={avtale.gjeldendeInnhold.refusjonKontaktperson?.refusjonKontaktpersonTlf}
+                                settVerdi={(verdi) =>
+                                    settAvtaleInnholdVerdi('refusjonKontaktperson', {
+                                        ...avtale.gjeldendeInnhold.refusjonKontaktperson,
+                                        refusjonKontaktpersonTlf: verdi ?? '',
+                                    })
+                                }
+                            />
+                        </div>
+                        <div>
+                            <Checkbox
+                                checked={avtale.gjeldendeInnhold?.refusjonKontaktperson?.ønskerVarslingOmRefusjon}
+                                onChange={() => sjekkeOmVarslingOmRefusjonKanSkrusAv()}
+                            >
+                                Arbeidsgiver for avtalen {getArbeidsgivernavn()} ønsker også å motta varslinger om
+                                refusjon
+                            </Checkbox>
+                        </div>
+                        {feilmelding && (
+                            <Alert variant="warning" style={{ marginBottom: '1rem' }}>
+                                {feilmelding}
+                            </Alert>
+                        )}
+                        <Button variant="secondary" onClick={() => resetRefusjonKontaktPerson()}>
+                            Fjern kontaktperson
+                        </Button>
+                    </>
+                )}
+            </Fieldset>
+        </div>
     );
 };
 

--- a/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
+++ b/src/AvtaleSide/steg/KontaktInformasjonSteg/VeilederinfoDel/VeilederinfoDel.tsx
@@ -4,59 +4,57 @@ import VerticalSpacer from '@/komponenter/layout/VerticalSpacer';
 import PakrevdInput from '@/komponenter/PakrevdInput/PakrevdInput';
 import TelefonnummerInput from '@/komponenter/TelefonnummerInput/TelefonnummerInput';
 import BEMHelper from '@/utils/bem';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { InnloggetBrukerContext } from '@/InnloggingBoundary/InnloggingBoundary';
 import { Alert } from '@navikt/ds-react';
 
 const VeilederinfoDel = () => {
     const cls = BEMHelper('kontaktinfo');
     const { avtale, settAvtaleInnholdVerdi } = useContext(AvtaleContext);
-    const { rolle, identifikator } = useContext(InnloggetBrukerContext);
+    const { rolle } = useContext(InnloggetBrukerContext);
 
     return (
-        <>
-            <div className={cls.element('container')}>
-                <SkjemaTittel>Kontaktperson i NAV</SkjemaTittel>
-                {rolle === 'VEILEDER' && (
-                    <>
-                        {avtale.veilederNavIdent && (
-                            <p>
-                                Eier av avtalen er{' '}
-                                <b>
-                                    <u>{avtale.veilederNavIdent}</u>
-                                </b>
-                                .
-                            </p>
-                        )}
-                        {!avtale.veilederNavIdent && <Alert variant={'warning'}>Det er ingen eier av avtalen.</Alert>}
+        <div className={cls.element('container')}>
+            <SkjemaTittel>Kontaktperson i NAV</SkjemaTittel>
+            {rolle === 'VEILEDER' && (
+                <>
+                    {avtale.veilederNavIdent && (
                         <p>
-                            For å overta avtalen må du eller en ny veileder gå til menyen og velge "Overta avtale" i
-                            tillegg til å skrive inn navn og telefonnummer her.
+                            Eier av avtalen er{' '}
+                            <b>
+                                <u>{avtale.veilederNavIdent}</u>
+                            </b>
+                            .
                         </p>
-                    </>
-                )}
-                <div className={cls.element('rad')}>
-                    <PakrevdInput
-                        label="Fornavn"
-                        verdi={avtale.gjeldendeInnhold.veilederFornavn}
-                        settVerdi={(verdi) => settAvtaleInnholdVerdi('veilederFornavn', verdi)}
-                    />
-                    <PakrevdInput
-                        label="Etternavn"
-                        verdi={avtale.gjeldendeInnhold.veilederEtternavn}
-                        settVerdi={(verdi) => settAvtaleInnholdVerdi('veilederEtternavn', verdi)}
-                    />
-                </div>
-                <VerticalSpacer rem={1} />
-                <div className={cls.element('rad')}>
-                    <TelefonnummerInput
-                        label="Mobilnummer"
-                        verdi={avtale.gjeldendeInnhold.veilederTlf}
-                        settVerdi={(verdi) => settAvtaleInnholdVerdi('veilederTlf', verdi)}
-                    />
-                </div>
+                    )}
+                    {!avtale.veilederNavIdent && <Alert variant={'warning'}>Det er ingen eier av avtalen.</Alert>}
+                    <p>
+                        For å overta avtalen må du eller en ny veileder gå til menyen og velge "Overta avtale" i tillegg
+                        til å skrive inn navn og telefonnummer her.
+                    </p>
+                </>
+            )}
+            <div className={cls.element('rad')}>
+                <PakrevdInput
+                    label="Fornavn"
+                    verdi={avtale.gjeldendeInnhold.veilederFornavn}
+                    settVerdi={(verdi) => settAvtaleInnholdVerdi('veilederFornavn', verdi)}
+                />
+                <PakrevdInput
+                    label="Etternavn"
+                    verdi={avtale.gjeldendeInnhold.veilederEtternavn}
+                    settVerdi={(verdi) => settAvtaleInnholdVerdi('veilederEtternavn', verdi)}
+                />
             </div>
-        </>
+            <VerticalSpacer rem={1} />
+            <div className={cls.element('rad')}>
+                <TelefonnummerInput
+                    label="Mobilnummer"
+                    verdi={avtale.gjeldendeInnhold.veilederTlf}
+                    settVerdi={(verdi) => settAvtaleInnholdVerdi('veilederTlf', verdi)}
+                />
+            </div>
+        </div>
     );
 };
 


### PR DESCRIPTION
Nå vil backend fylle inn bedriftnavn automatisk for alle avtaler (opprettet av veileder og arbeidsgiver), og da vil vi ikke at det skal kunne redigeres.