### PR TITLE
Vis at tilskuddsbeløp mangler i stedet for '0 kr'

### DIFF
--- a/src/AvtaleSide/steg/BeregningTilskudd/tilskuddsPerioder/TilskuddsPerioderVeileder.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/tilskuddsPerioder/TilskuddsPerioderVeileder.tsx
@@ -3,10 +3,9 @@ import { TilskuddsPeriode } from '@/types/avtale';
 import BEMHelper from '@/utils/bem';
 import { formaterPeriode } from '@/utils/datoUtils';
 import { formaterProsent } from '@/utils/formaterProsent';
-import { formaterPenger } from '@/utils/PengeUtils';
+import { formaterPenger, IKKE_NOE_BELOP_TEGN } from '@/utils/PengeUtils';
 import { FunctionComponent } from 'react';
 import './tilskuddsPerioder.less';
-import { erNil } from '@/utils/predicates';
 
 const cls = BEMHelper('tilskuddsPerioder');
 
@@ -38,7 +37,7 @@ const TilskuddsPerioderVeileder: FunctionComponent<Props> = (props) => {
                                     {formaterPeriode(periode.startDato, periode.sluttDato)}
                                 </td>
                                 <td>{formaterProsent(periode.lonnstilskuddProsent)}</td>
-                                <td>{erNil(periode.beløp) ? '—' : formaterPenger(periode.beløp)}</td>
+                                <td>{formaterPenger(periode.beløp, IKKE_NOE_BELOP_TEGN)}</td>
                                 <td>
                                     <EtikettStatus tilskuddsperiodestatus={periode.status} size="small" />
                                 </td>

--- a/src/AvtaleSide/steg/BeregningTilskudd/tilskuddsPerioder/TilskuddsPerioderVeileder.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/tilskuddsPerioder/TilskuddsPerioderVeileder.tsx
@@ -6,6 +6,7 @@ import { formaterProsent } from '@/utils/formaterProsent';
 import { formaterPenger } from '@/utils/PengeUtils';
 import { FunctionComponent } from 'react';
 import './tilskuddsPerioder.less';
+import { erNil } from '@/utils/predicates';
 
 const cls = BEMHelper('tilskuddsPerioder');
 
@@ -37,7 +38,7 @@ const TilskuddsPerioderVeileder: FunctionComponent<Props> = (props) => {
                                     {formaterPeriode(periode.startDato, periode.sluttDato)}
                                 </td>
                                 <td>{formaterProsent(periode.lonnstilskuddProsent)}</td>
-                                <td>{formaterPenger(periode.beløp)}</td>
+                                <td>{erNil(periode.beløp) ? '—' : formaterPenger(periode.beløp)}</td>
                                 <td>
                                     <EtikettStatus tilskuddsperiodestatus={periode.status} size="small" />
                                 </td>

--- a/src/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/TilskuddsperiodeTabellRad.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/TilskuddsperiodeTabellRad.tsx
@@ -4,8 +4,7 @@ import { addDays, getYear, isWithinInterval } from 'date-fns';
 import { BodyShort, Table } from '@navikt/ds-react';
 import { formaterDato, formaterPeriode } from '@/utils/datoUtils';
 import EtikettStatus from '@/BeslutterSide/EtikettStatus';
-import { formaterPenger } from '@/utils';
-import { erNil } from '@/utils/predicates';
+import { formaterPenger, IKKE_NOE_BELOP_TEGN } from '@/utils';
 
 const TilskuddsperiodeRad: React.FC<{
     avtaleOpprettet: Date;
@@ -40,7 +39,7 @@ const TilskuddsperiodeRad: React.FC<{
                 </Table.DataCell>
             )}
             <Table.DataCell align="right" textSize="small">
-                {erNil(periode.beløp) ? '—' : formaterPenger(periode.beløp)}
+                {formaterPenger(periode.beløp, IKKE_NOE_BELOP_TEGN)}
             </Table.DataCell>
             <Table.DataCell textSize="small">
                 {formaterDato(addDays(new Date(periode.sluttDato), 3).toString(), 'dd MMM yyyy')}

--- a/src/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/TilskuddsperiodeTabellRad.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/TilskuddsperiodeTabellRad.tsx
@@ -5,6 +5,7 @@ import { BodyShort, Table } from '@navikt/ds-react';
 import { formaterDato, formaterPeriode } from '@/utils/datoUtils';
 import EtikettStatus from '@/BeslutterSide/EtikettStatus';
 import { formaterPenger } from '@/utils';
+import { erNil } from '@/utils/predicates';
 
 const TilskuddsperiodeRad: React.FC<{
     avtaleOpprettet: Date;
@@ -39,7 +40,7 @@ const TilskuddsperiodeRad: React.FC<{
                 </Table.DataCell>
             )}
             <Table.DataCell align="right" textSize="small">
-                {periode.beløp !== null ? formaterPenger(periode.beløp) : '—'}
+                {erNil(periode.beløp) ? '—' : formaterPenger(periode.beløp)}
             </Table.DataCell>
             <Table.DataCell textSize="small">
                 {formaterDato(addDays(new Date(periode.sluttDato), 3).toString(), 'dd MMM yyyy')}

--- a/src/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/VisningTilskuddsperioderTabell.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/VisningTilskuddsperioderTabell.tsx
@@ -3,7 +3,7 @@ import { Table } from '@navikt/ds-react';
 import { TilskuddsPeriode } from '@/types/avtale';
 import { formaterPeriode } from '@/utils/datoUtils';
 import EtikettStatus from '@/BeslutterSide/EtikettStatus';
-import { formaterPenger } from '@/utils/PengeUtils';
+import { formaterPenger, IKKE_NOE_BELOP_TEGN } from '@/utils/PengeUtils';
 import InfoRundtTilskuddsperioder from '@/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/InfoRundtTilskuddsperioder';
 import BEMHelper from '@/utils/bem';
 import { InnloggetBrukerContext } from '@/InnloggingBoundary/InnloggingBoundary';
@@ -13,7 +13,6 @@ import {
     getIndexVisningForTilskuddsperiode,
 } from '@/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/visningTilskuddsperiodeUtils';
 import VerticalSpacer from '@/komponenter/layout/VerticalSpacer';
-import { erNil } from '@/utils/predicates';
 
 interface Properties {
     className: string;
@@ -82,7 +81,7 @@ const VisningTilskuddsperioderTabell: React.FC<Properties> = ({ className }: Pro
                                         )}
                                     </Table.DataCell>
                                     <Table.DataCell textSize="small">
-                                        {erNil(periode.beløp) ? '—' : formaterPenger(periode.beløp)}
+                                        {formaterPenger(periode.beløp, IKKE_NOE_BELOP_TEGN)}
                                     </Table.DataCell>
                                 </Table.Row>
                             );

--- a/src/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/VisningTilskuddsperioderTabell.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/VisningTilskuddsperioderTabell.tsx
@@ -13,6 +13,7 @@ import {
     getIndexVisningForTilskuddsperiode,
 } from '@/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/visningTilskuddsperiodeUtils';
 import VerticalSpacer from '@/komponenter/layout/VerticalSpacer';
+import { erNil } from '@/utils/predicates';
 
 interface Properties {
     className: string;
@@ -80,7 +81,9 @@ const VisningTilskuddsperioderTabell: React.FC<Properties> = ({ className }: Pro
                                             <>{periode.lonnstilskuddProsent}%</>
                                         )}
                                     </Table.DataCell>
-                                    <Table.DataCell textSize="small">{formaterPenger(periode.beløp)}</Table.DataCell>
+                                    <Table.DataCell textSize="small">
+                                        {erNil(periode.beløp) ? '—' : formaterPenger(periode.beløp)}
+                                    </Table.DataCell>
                                 </Table.Row>
                             );
                         })}

--- a/src/BeslutterSide/beslutterTilskuddsperioder/BeslutterTilskuddsperioder.tsx
+++ b/src/BeslutterSide/beslutterTilskuddsperioder/BeslutterTilskuddsperioder.tsx
@@ -149,7 +149,7 @@ const BeslutterTilskuddsPerioder: FunctionComponent<Props> = (props) => {
                                         >
                                             {formaterPeriode(periode.startDato, periode.sluttDato, 'dd.MM.yy')}
                                         </td>
-                                        <td>{formaterPenger(periode.beløp)}</td>
+                                        <td>{erNil(periode.beløp) ? '—' : formaterPenger(periode.beløp)}</td>
                                         <td>{formaterProsent(periode.lonnstilskuddProsent)}</td>
                                         <td>{formaterDato(periode.kanBesluttesFom, NORSK_DATO_FORMAT)}</td>
                                         <td>{periode.status === 'GODKJENT' ? periode.enhet : enhet}</td>

--- a/src/BeslutterSide/beslutterTilskuddsperioder/BeslutterTilskuddsperioder.tsx
+++ b/src/BeslutterSide/beslutterTilskuddsperioder/BeslutterTilskuddsperioder.tsx
@@ -1,7 +1,7 @@
 import { AvtaleContext, Context } from '@/AvtaleProvider';
 import { formaterDato, formaterPeriode, NORSK_DATO_FORMAT_FULL, NORSK_DATO_FORMAT } from '@/utils/datoUtils';
 import { formaterProsent } from '@/utils/formaterProsent';
-import { formaterPenger } from '@/utils/PengeUtils';
+import { formaterPenger, IKKE_NOE_BELOP_TEGN } from '@/utils/PengeUtils';
 import React, { FunctionComponent, useContext, useRef, useState, useEffect } from 'react';
 import EtikettStatus from '../EtikettStatus';
 import BEMHelper from '@/utils/bem';
@@ -149,7 +149,7 @@ const BeslutterTilskuddsPerioder: FunctionComponent<Props> = (props) => {
                                         >
                                             {formaterPeriode(periode.startDato, periode.sluttDato, 'dd.MM.yy')}
                                         </td>
-                                        <td>{erNil(periode.beløp) ? '—' : formaterPenger(periode.beløp)}</td>
+                                        <td>{formaterPenger(periode.beløp, IKKE_NOE_BELOP_TEGN)}</td>
                                         <td>{formaterProsent(periode.lonnstilskuddProsent)}</td>
                                         <td>{formaterDato(periode.kanBesluttesFom, NORSK_DATO_FORMAT)}</td>
                                         <td>{periode.status === 'GODKJENT' ? periode.enhet : enhet}</td>

--- a/src/types/avtale.ts
+++ b/src/types/avtale.ts
@@ -295,7 +295,7 @@ export type ArbeidsAvgiftSats = 0.141 | 0.106 | 0.064 | 0.051 | 0.079 | 0;
 export type FerieSatser = 0 | 0.12 | 0.143 | 0.102 | 0.125;
 
 export interface TilskuddsPeriode {
-    beløp: number;
+    beløp?: number;
     løpenummer: number;
     id: string;
     startDato: string;

--- a/src/utils/PengeUtils.ts
+++ b/src/utils/PengeUtils.ts
@@ -1,5 +1,17 @@
-export const formaterPenger = (penger: number) =>
-    `${new Intl.NumberFormat('nb-NO', {
+import { erNil } from './predicates';
+
+const IKKE_NOE_BELOP_TEGN = '—';
+
+function formaterPenger(penger: number | undefined, ikkeNoeBelopTegn: string): string;
+function formaterPenger(penger: number, ikkeNoeBelopTegn?: undefined): string;
+function formaterPenger(penger: number | undefined, ikkeNoeBelopTegn?: string): string {
+    if (!erNil(ikkeNoeBelopTegn) && erNil(penger)) {
+        return ikkeNoeBelopTegn;
+    }
+    return `${new Intl.NumberFormat('nb-NO', {
         style: 'decimal',
         maximumFractionDigits: 2,
-    }).format(penger)} kr`;
+    }).format(penger as number)} kr`; // OBS: function overloading fanger at 'penger' ikke er undefined her
+}
+
+export { formaterPenger, IKKE_NOE_BELOP_TEGN };


### PR DESCRIPTION
Dersom en beslutter går inn for å godkjenne en VTAO-avtale hvor sats mangler (feks for neste år), så vises det som at beløpet er '0 kr', i stedet for at man får se at beløpet faktisk mangler.