### PR TITLE
fix. lang titel på avtale får linebreak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@hookform/resolvers": "3.10.0",
                 "@navikt/arbeidsgiver-notifikasjon-widget": "^7.2.3",
-                "@navikt/bedriftsmeny": "^7.0.5",
+                "@navikt/bedriftsmeny": "^7.0.6",
                 "@navikt/ds-css": "^7.18.0",
                 "@navikt/ds-react": "^7.18.0",
                 "@navikt/navspa": "^6.0.1",
@@ -1281,9 +1281,9 @@
             }
         },
         "node_modules/@navikt/bedriftsmeny": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@navikt/bedriftsmeny/-/bedriftsmeny-7.0.5.tgz",
-            "integrity": "sha512-yqZFHUVm7l2DBDs+/be+d6SJW550M+k4cJlAqhRadUcVveVu008H0dHH9FucupwJah6rxL1ZPqyFyxkMzmK/pw==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@navikt/bedriftsmeny/-/bedriftsmeny-7.0.6.tgz",
+            "integrity": "sha512-wEKekSA0cvJptgiG0+q+dwgBXdNDCldK/3RrPm5ipvG87I8rIkZDrh+f3adR1dHF0TDYhj4iv2erjSknxL+eag==",
             "license": "MIT",
             "dependencies": {
                 "focus-trap-react": "^10.2.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@hookform/resolvers": "3.10.0",
         "@navikt/arbeidsgiver-notifikasjon-widget": "^7.2.3",
-        "@navikt/bedriftsmeny": "^7.0.5",
+        "@navikt/bedriftsmeny": "^7.0.6",
         "@navikt/ds-css": "^7.18.0",
         "@navikt/ds-react": "^7.18.0",
         "@navikt/navspa": "^6.0.1",


### PR DESCRIPTION
https://trello.com/c/Jf24VlOg/1792-header-i-bedriftsmenyen-er-broken

# Går fra 
![image](https://github.com/user-attachments/assets/b9d90143-60cf-4561-91dc-8d6ed0722e0b)

# till

<img width="848" alt="image" src="https://github.com/user-attachments/assets/f8e46826-6b76-4f04-96e5-1ec2374c3aa4" />


# skrev i slacken og de oppdaterte den fixerN
[bedriftsmeny slack](https://nav-it.slack.com/archives/CTC925S11/p1745912989634559)
