### PR TITLE
Legg til logg-destinasjoner

### DIFF
--- a/nais/nais-gcp-ekstern.yaml
+++ b/nais/nais-gcp-ekstern.yaml
@@ -48,6 +48,14 @@ spec:
       level: Level4
       locale: nb
       autoLogin: false
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: nodejs
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   accessPolicy:
     outbound:
       rules:

--- a/nais/nais-gcp-intern.yaml
+++ b/nais/nais-gcp-intern.yaml
@@ -46,6 +46,14 @@ spec:
           - "NAVident"
     sidecar:
       enabled: true
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: nodejs
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   accessPolicy:
     outbound:
       rules:


### PR DESCRIPTION
Vi ønsker å eksportere loggene våre til kibana
selv etter 1. juni!

Nais-plattformen har deprekert elasticsearch, og
derfor må vi eksplisitt legge til elastic til
listen over logg-destinasjoner i nais-yaml'en