### PR TITLE
fix. reset nettresurs i filter ved 403

### DIFF
--- a/src/AvtaleOversikt/Avtaler.tsx
+++ b/src/AvtaleOversikt/Avtaler.tsx
@@ -7,12 +7,12 @@ import { FeilVarselContext } from '@/FeilVarselProvider';
 import IkkeTilgang403 from '@/Router/IkkeTilgang403';
 import { PageableAvtalelisteRessurs } from '@/types/avtale';
 import { IkkeTilgangError } from '@/types/errors';
-import { Feilkode, Feilmeldinger } from '@/types/feilkode';
 import { InnloggetBruker } from '@/types/innlogget-bruker';
 import { Status } from '@/types/nettressurs';
 import { Varsel } from '@/types/varsel';
 import { handterFeil } from '@/utils/apiFeilUtils';
 import { FunctionComponent, useContext } from 'react';
+import ResetFilterVedEndring from '@/AvtaleOversikt/Filtrering/ResetFilterVedEndring';
 
 type Props = {
     avtalelisteRessurs: PageableAvtalelisteRessurs;
@@ -26,16 +26,16 @@ export const Avtaler: FunctionComponent<Props> = (props) => {
     const feilVarsel = useContext(FeilVarselContext);
     const layout = useAvtaleOversiktLayout();
 
-    if (props.avtalelisteRessurs.status === Status.LasterInn) {
+    if (props.avtalelisteRessurs.status === Status.LASTER_INN) {
         return <AvtaleOversiktSkeleton erNavAnsatt={props.innloggetBruker.erNavAnsatt} />;
     } else if (
-        props.avtalelisteRessurs.status === Status.Lastet &&
+        props.avtalelisteRessurs.status === Status.LASTET &&
         props.avtalelisteRessurs.data.avtaler.length === 0
     ) {
         return <IngenAvtaler />;
     } else if (props.innloggetBruker.rolle === 'ARBEIDSGIVER' && harIngenAltinnTilganger(props.innloggetBruker)) {
         return <IngenAvtaler />;
-    } else if (props.avtalelisteRessurs.status === Status.Lastet) {
+    } else if (props.avtalelisteRessurs.status === Status.LASTET) {
         return layout.erNokPlassTilTabell ? (
             <AvtaleTabell
                 avtaler={props.avtalelisteRessurs.data.avtaler}
@@ -50,11 +50,15 @@ export const Avtaler: FunctionComponent<Props> = (props) => {
             />
         );
     } else if (
-        props.avtalelisteRessurs.status === Status.Feil &&
+        props.avtalelisteRessurs.status === Status.FEIL &&
         props.avtalelisteRessurs.error instanceof IkkeTilgangError
     ) {
-        return <IkkeTilgang403 enkelVisning feilkode={props.avtalelisteRessurs.error.message} />;
-    } else if (props.avtalelisteRessurs.status === Status.Feil) {
+        return (
+            <ResetFilterVedEndring>
+                <IkkeTilgang403 enkelVisning feilkode={props.avtalelisteRessurs.error.message} />
+            </ResetFilterVedEndring>
+        );
+    } else if (props.avtalelisteRessurs.status === Status.FEIL) {
         handterFeil(props.avtalelisteRessurs.error, feilVarsel);
     }
     return null;

--- a/src/AvtaleOversikt/Filtrering/FiltreringProvider.tsx
+++ b/src/AvtaleOversikt/Filtrering/FiltreringProvider.tsx
@@ -23,18 +23,18 @@ export const FiltreringContext = createContext<
         PageableAvtalelisteRessurs,
         Dispatch<SetStateAction<PageableAvtalelisteRessurs>>,
     ]
->([{}, () => null, { status: Status.IkkeLastet }, () => null]);
+>([{}, () => null, { status: Status.IKKE_LASTET }, () => null]);
 
 export const FiltreringProvider: FunctionComponent<PropsWithChildren> = (props) => {
     const innloggetBruker = useContext(InnloggetBrukerContext);
     const [searchParams, setSearchParams] = useSearchParams();
-    const [nettressursCtx, setNettressursCtx] = useState<PageableAvtalelisteRessurs>({ status: Status.IkkeLastet });
+    const [nettressursCtx, setNettressursCtx] = useState<PageableAvtalelisteRessurs>({ status: Status.IKKE_LASTET });
     const params: any = {};
     const [filtre, setFiltre] = useState<Filtrering>(params);
 
     useEffect(() => {
         // KJØR EN GANG PÅ OPPSTART
-        if (nettressursCtx.status !== Status.IkkeLastet) return;
+        if (nettressursCtx.status !== Status.IKKE_LASTET) return;
         if (innloggetBruker.rolle === 'BESLUTTER') return;
         if (innloggetBruker.rolle === 'ARBEIDSGIVER' && !filtre.bedriftNr) return;
 
@@ -42,7 +42,7 @@ export const FiltreringProvider: FunctionComponent<PropsWithChildren> = (props) 
         const bedriftNrISøkekriterier = bedriftNr && bedriftNr.trim().length === 9 ? { bedriftNr: bedriftNr } : {};
         const tekniskPage = searchParams.get('page') ? parseInt(searchParams.get('page')!, 10) - 1 : 0;
         let resultat;
-        setNettressursCtx({ status: Status.LasterInn });
+        setNettressursCtx({ status: Status.LASTER_INN });
         const sorteringskolonne = (searchParams.get('sorteringskolonne') as keyof Avtale) || 'sistEndret';
         const sorteringOrder = searchParams.get('sorteringOrder') || 'ASC';
         let erGet = false;
@@ -68,7 +68,7 @@ export const FiltreringProvider: FunctionComponent<PropsWithChildren> = (props) 
                 if (pagableAvtale.sokId === '') {
                     // ugyldig sokId - Utfører blankt søk.
                     hentAvtalerForInnloggetBrukerMedPost(filtre, 10, 0).then((pagableAvtale: PageableAvtale) => {
-                        setNettressursCtx({ status: Status.Lastet, data: pagableAvtale });
+                        setNettressursCtx({ status: Status.LASTET, data: pagableAvtale });
                         setSearchParams({
                             sokId: pagableAvtale.sokId,
                             page: '' + (pagableAvtale.currentPage + 1),
@@ -103,7 +103,7 @@ export const FiltreringProvider: FunctionComponent<PropsWithChildren> = (props) 
                         });
                         setSearchParams(sokeParams, { replace: true });
                     }
-                    setNettressursCtx({ status: Status.Lastet, data: pagableAvtale });
+                    setNettressursCtx({ status: Status.LASTET, data: pagableAvtale });
                     setFiltre({
                         ...pagableAvtale.sokeParametere,
                         page: pagableAvtale.currentPage + 1 + '',
@@ -113,7 +113,7 @@ export const FiltreringProvider: FunctionComponent<PropsWithChildren> = (props) 
                 }
             })
             .catch((error) => {
-                setNettressursCtx({ status: Status.Feil, error });
+                setNettressursCtx({ status: Status.FEIL, error });
             });
     }, [filtre, nettressursCtx.status, searchParams, setSearchParams, innloggetBruker.rolle]);
 

--- a/src/AvtaleOversikt/Filtrering/ResetFilterVedEndring.tsx
+++ b/src/AvtaleOversikt/Filtrering/ResetFilterVedEndring.tsx
@@ -1,0 +1,22 @@
+import React, { useContext, useEffect, useRef } from 'react';
+import { FiltreringContext } from '@/AvtaleOversikt/Filtrering/FiltreringProvider';
+import { Status } from '@/types/nettressurs';
+
+type Props = React.PropsWithChildren;
+
+function ResetFilterVedEndring(props: Props) {
+    const { children } = props;
+    const [filter, , , setNettressursCtx] = useContext(FiltreringContext);
+    const filterRef = useRef(filter);
+
+    useEffect(() => {
+        if (filterRef.current !== filter) {
+            setNettressursCtx({ status: Status.OMLAST });
+            filterRef.current = filter;
+        }
+    }, [filter, filterRef, setNettressursCtx]);
+
+    return children;
+}
+
+export default ResetFilterVedEndring;

--- a/src/AvtaleSide/Varsellogg/Varsellogg.tsx
+++ b/src/AvtaleSide/Varsellogg/Varsellogg.tsx
@@ -15,16 +15,16 @@ const cls = BEMHelper('varsellogg');
 
 const Varsellogg: FunctionComponent = () => {
     const [varselLoggModalApen, setVarselLoggModalApen] = useState<boolean>(false);
-    const [varsler, setVarsler] = useState<Nettressurs<Varsel[]>>({ status: Status.IkkeLastet });
+    const [varsler, setVarsler] = useState<Nettressurs<Varsel[]>>({ status: Status.IKKE_LASTET });
     const avtaleContext = useContext(AvtaleContext);
 
     useEffect(() => {
-        setVarsler({ status: Status.LasterInn });
+        setVarsler({ status: Status.LASTER_INN });
         // Hent nye varselr når loggen åpnes.
         if (varselLoggModalApen) {
             hentVarsellogg(avtaleContext.avtale.id)
-                .then((data: Varsel[]) => setVarsler({ status: Status.Lastet, data }))
-                .catch((error: Error) => setVarsler({ status: Status.Feil, error: error }));
+                .then((data: Varsel[]) => setVarsler({ status: Status.LASTET, data }))
+                .catch((error: Error) => setVarsler({ status: Status.FEIL, error: error }));
         }
     }, [avtaleContext.avtale.id, varselLoggModalApen]);
 
@@ -64,13 +64,13 @@ const Varsellogg: FunctionComponent = () => {
                             <VerticalSpacer rem={1} />
                         </>
                     )}
-                    {varsler.status === Status.Lastet && varsler.data.length > 0 && (
+                    {varsler.status === Status.LASTET && varsler.data.length > 0 && (
                         <VarselTabell varsler={varsler.data} />
                     )}
-                    {varsler.status === Status.LasterInn && (
+                    {varsler.status === Status.LASTER_INN && (
                         <Loader variant="neutral" size="xlarge" className={cls.element('spinner')} />
                     )}
-                    {varsler.status === Status.Feil && (
+                    {varsler.status === Status.FEIL && (
                         <BodyShort size="small">Klarte ikke hente hendelselogg. Prøv igjen senere.</BodyShort>
                     )}
                 </Modal.Body>

--- a/src/BeslutterOversikt/AvtalerBeslutter.tsx
+++ b/src/BeslutterOversikt/AvtalerBeslutter.tsx
@@ -17,13 +17,13 @@ type Props = {
 
 export const AvtalerBeslutter: FunctionComponent<Props> = (props) => {
     const feilVarsel = useContext(FeilVarselContext);
-    if (props.avtalelisteRessurs.status === Status.LasterInn) {
+    if (props.avtalelisteRessurs.status === Status.LASTER_INN) {
         return <BeslutterOversiktSkeleton erNavAnsatt={props.innloggetBruker.erNavAnsatt} />;
-    } else if (props.avtalelisteRessurs.status === Status.Lastet && props.avtalelisteRessurs.data.length === 0) {
+    } else if (props.avtalelisteRessurs.status === Status.LASTET && props.avtalelisteRessurs.data.length === 0) {
         return <IngenAvtaler />;
-    } else if (props.avtalelisteRessurs.status === Status.Lastet) {
+    } else if (props.avtalelisteRessurs.status === Status.LASTET) {
         return <AvtaleTabellBeslutter avtaler={props.avtalelisteRessurs.data} varsler={props.varsler} />;
-    } else if (props.avtalelisteRessurs.status === Status.Feil) {
+    } else if (props.avtalelisteRessurs.status === Status.FEIL) {
         handterFeil(props.avtalelisteRessurs.error, feilVarsel);
     }
     return null;

--- a/src/BeslutterOversikt/BeslutterOversikt.tsx
+++ b/src/BeslutterOversikt/BeslutterOversikt.tsx
@@ -21,16 +21,16 @@ const BeslutterOversikt: FunctionComponent = () => {
     const { filtre, endreFilter } = useFilterGammel();
     const [currentPage, setCurrentPage] = useState<PageableAvtaleMinimalForBeslutter>();
     const [nettressurs, setNettressurs] = useState<AvtalelisteMinimalForBeslutterRessurs>({
-        status: Status.IkkeLastet,
+        status: Status.IKKE_LASTET,
     });
 
     useEffect(() => {
-        setNettressurs({ status: Status.LasterInn });
+        setNettressurs({ status: Status.LASTER_INN });
         const page = parseInt(filtre.page ? filtre.page : '1', 10);
         hentAvtalerForInnloggetBeslutter(filtre, 10, page - 1).then(
             (pagableAvtale: PageableAvtaleMinimalForBeslutter) => {
                 setCurrentPage(pagableAvtale);
-                setNettressurs({ status: Status.Lastet, data: pagableAvtale.avtaler });
+                setNettressurs({ status: Status.LASTET, data: pagableAvtale.avtaler });
             },
         );
     }, [filtre]);
@@ -62,7 +62,7 @@ const BeslutterOversikt: FunctionComponent = () => {
                             varsler={[]}
                         />
                         <div className={clsPagination.className}>
-                            {pageNumber && nettressurs.status === Status.Lastet && currentPage!.totalPages > 0 && (
+                            {pageNumber && nettressurs.status === Status.LASTET && currentPage!.totalPages > 0 && (
                                 <>
                                     <Pagination
                                         page={pageNumber}

--- a/src/Router/IkkeTilgang403.tsx
+++ b/src/Router/IkkeTilgang403.tsx
@@ -5,7 +5,6 @@ import Innholdsboks from '@/komponenter/Innholdsboks/Innholdsboks';
 import { Rolle } from '@/types/innlogget-bruker';
 
 import { Path } from './Router';
-import { ApiError, IkkeTilgangError } from '@/types';
 import { Feilkode, Feilmeldinger } from '@/types/feilkode';
 
 interface Props {

--- a/src/komponenter/lagreOgAvbrytKnapp/LagreOgAvbrytKnapp.tsx
+++ b/src/komponenter/lagreOgAvbrytKnapp/LagreOgAvbrytKnapp.tsx
@@ -16,7 +16,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 
 const LagreOgAvbrytKnapp: FunctionComponent<Props & ButtonProps> = (props) => {
     const cls = BEMHelper('lagre-og-avbryt-knapp');
-    const [oppslag, setOppslag] = useState<Nettressurs<any>>({ status: Status.IkkeLastet });
+    const [oppslag, setOppslag] = useState<Nettressurs<any>>({ status: Status.IKKE_LASTET });
     const [feilmelding, setFeilmelding] = useState('');
 
     // Fjerner ikke-standard knapp-props før de spreades inn i KnappBase.
@@ -26,25 +26,25 @@ const LagreOgAvbrytKnapp: FunctionComponent<Props & ButtonProps> = (props) => {
 
     const onClick = async () => {
         try {
-            setOppslag({ status: Status.LasterInn });
+            setOppslag({ status: Status.LASTER_INN });
             // midlertidig fiks. Må fikse mem-leak før denne kan pushes under callback lagreFunksjon.
             await props.lagreFunksjon();
-            setOppslag({ status: Status.Sendt });
+            setOppslag({ status: Status.SENDT });
         } catch (error: any) {
-            setOppslag({ status: Status.Feil, error: error.feilmelding ?? 'Uventet feil' });
+            setOppslag({ status: Status.FEIL, error: error.feilmelding ?? 'Uventet feil' });
             handterFeil(error, setFeilmelding);
         }
     };
 
     useEffect(() => {
-        if (oppslag.status === Status.Feil) {
+        if (oppslag.status === Status.FEIL) {
             feilRef.current?.focus();
         }
     }, [oppslag.status]);
 
     return (
         <div className={classNames(props.className, cls.className)}>
-            {oppslag.status === Status.Feil && (
+            {oppslag.status === Status.FEIL && (
                 <div className={cls.element('alert')}>
                     <Alert size="small" variant="warning">
                         <div ref={feilRef} aria-live="polite">
@@ -59,8 +59,8 @@ const LagreOgAvbrytKnapp: FunctionComponent<Props & ButtonProps> = (props) => {
                 </Button>
                 <Button
                     type="submit"
-                    loading={oppslag.status === Status.LasterInn}
-                    disabled={oppslag.status === Status.LasterInn}
+                    loading={oppslag.status === Status.LASTER_INN}
+                    disabled={oppslag.status === Status.LASTER_INN}
                     onClick={onClick}
                     variant="primary"
                     {...knappBaseProps}

--- a/src/types/nettressurs.ts
+++ b/src/types/nettressurs.ts
@@ -1,37 +1,42 @@
 export enum Status {
-    'IkkeLastet',
-    'LasterInn',
-    'SenderInn',
-    'Lastet',
-    'Sendt',
-    'Feil',
+    IKKE_LASTET,
+    LASTER_INN,
+    SENDER_INN,
+    LASTET,
+    SENDT,
+    FEIL,
+    OMLAST,
 }
 
 export interface IkkeLastet {
-    status: Status.IkkeLastet;
+    status: Status.IKKE_LASTET;
 }
 
 export interface LasterInn {
-    status: Status.LasterInn;
+    status: Status.LASTER_INN;
 }
 
 export interface SenderInn<T> {
-    status: Status.SenderInn;
+    status: Status.SENDER_INN;
     data: T;
 }
 
 export interface Lastet<T> {
-    status: Status.Lastet;
+    status: Status.LASTET;
     data: T;
 }
 
 export interface Sendt {
-    status: Status.Sendt;
+    status: Status.SENDT;
 }
 
 export interface Feil {
-    status: Status.Feil;
+    status: Status.FEIL;
     error: Error;
 }
 
-export type Nettressurs<T> = IkkeLastet | LasterInn | SenderInn<T> | Lastet<T> | Sendt | Feil;
+export interface Omlast {
+    status: Status.OMLAST;
+}
+
+export type Nettressurs<T> = IkkeLastet | LasterInn | SenderInn<T> | Lastet<T> | Sendt | Feil | Omlast;


### PR DESCRIPTION
* Feilen er at det ikke går an å endre på filter dersom en 403 feil intreffer. Da er siste utvei å gjøre en omlast av siden. Derfor vil denne fiksen lytte på endringer i filter og sette nettresursen tilbake til.