### PR TITLE
Fjerner margin i EksternLenke mellom tekst og ikon

### DIFF
--- a/src/komponenter/navigation/EksternLenke.less
+++ b/src/komponenter/navigation/EksternLenke.less
@@ -1,4 +1,3 @@
 .ekstern-lenke-icon {
     display: inline-block;
-    margin-left: 0.3rem;
 }


### PR DESCRIPTION
før:
<img width="142" height="91" alt="image" src="https://github.com/user-attachments/assets/274efb2a-2537-4e51-afa7-ad1883bf83a1" />

etter:
<img width="142" height="91" alt="image" src="https://github.com/user-attachments/assets/e0577b8d-81ae-48c3-a501-88aace7075e9" />
