### PR TITLE
Endrer slikt at søknadsstart er dagen etter perioden er over

### DIFF
--- a/src/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/MeldingArbeidsgiverSokRefusjon.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/visningTilskuddsperioder/MeldingArbeidsgiverSokRefusjon.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { BodyShort, Heading, Label } from '@navikt/ds-react';
-import { formaterDato, NORSK_DATO_FORMAT_FULL } from '@/utils/datoUtils';
+import { beregnDagenEtterOgFormater } from '@/utils/datoUtils';
 import BEMHelper from '@/utils/bem';
 import { InnloggetBrukerContext } from '@/InnloggingBoundary/InnloggingBoundary';
 import { Avtale } from '@/types/avtale';
@@ -30,7 +30,7 @@ const MeldingArbeidsgiverSokRefusjon: React.FC<Props> = ({ className, avtale }: 
                 tilskuddsperioden er over, vil NAV sende dere et ferdig utregnet forslag til refusjon. Refusjonen regnes
                 ut på bakgrunn av innhold i avtalen og innrapporterte inntekter i A-meldingen.
             </BodyShort>
-            <Label>Du kan søke om refusjon fra {formaterDato(sluttdato, NORSK_DATO_FORMAT_FULL)}</Label>
+            <Label>Du kan søke om refusjon fra {beregnDagenEtterOgFormater(sluttdato)}</Label>
         </div>
     );
 };

--- a/src/OpprettAvtale/OpprettAvtaleArbeidsgiver/OpprettAvtaleArbeidsgiver.tsx
+++ b/src/OpprettAvtale/OpprettAvtaleArbeidsgiver/OpprettAvtaleArbeidsgiver.tsx
@@ -133,7 +133,7 @@ const OpprettAvtaleArbeidsgiver: FunctionComponent = () => {
                         Er det første gang du skal opprette en avtale bør du lese gjennom {''}
                         <EksternLenke href={`${basename}${Path.INFORMASJONSSIDE}`}>
                             introduksjon til hvordan løsningen fungerer {''}
-                        </EksternLenke>
+                        </EksternLenke>{' '}
                         og vite om{' '}
                         <EksternLenke href="https://www.nav.no/arbeidsgiver/inkludere">
                             de ulike støtteordningene.

--- a/src/OpprettAvtale/OpprettAvtaleVeileder/InformasjonsboksTopVeilederOppretterAvtale.tsx
+++ b/src/OpprettAvtale/OpprettAvtaleVeileder/InformasjonsboksTopVeilederOppretterAvtale.tsx
@@ -12,7 +12,7 @@ const InformasjonsboksTopVeilederOppretterAvtale: React.FC = () => {
                 Er det første gang du skal opprette en avtale bør du lese gjennom {''}
                 <EksternLenke href={`${basename}${Path.INFORMASJONSSIDE}`}>
                     introduksjon til hvordan løsningen fungerer {''}
-                </EksternLenke>
+                </EksternLenke>{' '}
                 og vite om{' '}
                 <EksternLenke href="https://www.nav.no/arbeidsgiver/inkludere">
                     de ulike støtteordningene på NAV.no.

--- a/src/utils/datoUtils.ts
+++ b/src/utils/datoUtils.ts
@@ -7,6 +7,7 @@ import {
     intervalToDuration,
     differenceInHours,
     isAfter,
+    addDays,
 } from 'date-fns';
 import { nb } from 'date-fns/locale';
 
@@ -54,6 +55,7 @@ export const NORSK_DATO_FORMAT_FULL = 'PPP';
  */
 export const formaterDato = (dato: Date | string, formatString: string = NORSK_DATO_OG_TID_FORMAT_FULL) => {
     try {
+        // behandlingsdato for første tilskuddsperiode får en hardkodet dato for å kunne behandles, vi ønsker ikke å vise denne
         if (dato === '-999999999-01-01') return '';
         return format(dato, formatString, { locale: nb });
     } catch (e) {
@@ -118,4 +120,10 @@ export const tidSidenTidspunktEllerDato = (tidspunkt: string | Date): string => 
         return 'om ' + tidSidenTidspunkt(tidspunkt);
     }
     return tidSidenTidspunkt(tidspunkt) + ' siden';
+};
+
+export const beregnDagenEtterOgFormater = (dato: string | Date, format: string = NORSK_DATO_FORMAT_FULL): string => {
+    // behandlingsdato for første tilskuddsperiode får en hardkodet dato for å kunne behandles, vi ønsker ikke å vise denne
+    if (dato === '-999999999-01-01') return '';
+    return formaterDato(addDays(dato, 1), format);
 };


### PR DESCRIPTION
* Enderer datoen i tekst slik at søknadsstart er dagen etter forrige periode er over
* Fikser også litten spacing feil der `EksternLenke`-komponenten er brukt