### PR TITLE
Refaktorer HvaMenesMedDette til å bruke Aksel-komponenter

### DIFF
--- a/src/AvtaleSide/steg/BeregningTilskudd/BeregningTilskuddSteg.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/BeregningTilskuddSteg.tsx
@@ -35,7 +35,7 @@ const BeregningTilskuddSteg: FunctionComponent = () => {
                 <Heading level="3" size="small" className={cls.element('lonn-tittel')}>
                     Lønn per måned i faktisk stillingsprosent inkludert faste og uregelmessige tillegg
                 </Heading>
-                <HvaMenesMedDette className={cls.className} />
+                <HvaMenesMedDette />
                 <Manedslonn cls={cls} />
                 <Row className={cls.element('rad')}>
                     <Column md="8" className={cls.element('feriepenger')}>

--- a/src/AvtaleSide/steg/BeregningTilskudd/HvaMenesMedDette.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/HvaMenesMedDette.tsx
@@ -1,50 +1,45 @@
 import React from 'react';
-import LesMerPanel from '@/komponenter/LesMerPanel/LesMerPanel';
-import BEMHelper from '@/utils/bem';
+import { BodyLong, List, ReadMore } from '@navikt/ds-react';
 
-interface Props {
-    className: string;
-}
-
-const HvaMenesMedDette: React.FC<Props> = ({ className }: Props) => {
-    const cls = BEMHelper(className);
+const HvaMenesMedDette: React.FC = () => {
     return (
-        <LesMerPanel className={cls.element('lonn-per-mnd')} åpneLabel="Hva menes med dette?" lukkLabel="Lukk">
-            <div className={cls.element('lonn-per-mnd-seksjon')}>
+        <ReadMore header="Hva menes med dette?">
+            <BodyLong spacing>
                 Brutto lønn omregnes til fast gjennomsnittlig månedslønn. I refusjonsgrunnlaget inngår lønn for arbeid
                 utført i normalarbeidstiden inkludert faste og uregelmessige tillegg. Overtidsbetaling og andre variable
-                tillegg skal ikke tas med. For deltidsstillinger skal lønn i den faktiske stillingsprosenten legges inn.
-                For eksempel hvis deltaker er ansatt i en 50 % stilling, skal det legges inn månedslønn i 50 % stilling
-                før skatt. Eventuelle lønnsutgifter som oversiger avtalt tilskuddsbeløp, vil ikke bli refundert.
-            </div>
-            <div className={cls.element('lonn-per-mnd-seksjon')}>
+                tillegg skal ikke tas med.
+            </BodyLong>
+            <BodyLong spacing>
+                For deltidsstillinger skal lønn i den faktiske stillingsprosenten legges inn. For eksempel hvis deltaker
+                er ansatt i en 50 % stilling, skal det legges inn månedslønn i 50 % stilling før skatt.
+            </BodyLong>
+            <BodyLong spacing>
+                Eventuelle lønnsutgifter som oversiger avtalt tilskuddsbeløp, vil ikke bli refundert.
+            </BodyLong>
+            <BodyLong>
                 Faste tillegg er knyttet til personlige egenskaper, evner eller ansvar og utbetales regelmessig ved hver
                 lønnsutbetaling. Beløpet er en fast størrelse og gjelder blant annet:
-            </div>
-            <div className={cls.element('lonn-per-mnd-seksjon')}>
-                <ul>
-                    <li>b-tillegg</li>
-                    <li>stabiliseringstillegg</li>
-                    <li>selektivt tillegg for sykepleiere</li>
-                    <li>tillegg for ansvarsvakter, fagansvar og lederansvar</li>
-                    <li>kvalifikasjons-/kompetansetillegg</li>
-                </ul>
-            </div>
-            <div className={cls.element('lonn-per-mnd-seksjon')}>
+            </BodyLong>
+            <List>
+                <List.Item>b-tillegg</List.Item>
+                <List.Item>stabiliseringstillegg</List.Item>
+                <List.Item>selektivt tillegg for sykepleiere</List.Item>
+                <List.Item>tillegg for ansvarsvakter, fagansvar og lederansvar</List.Item>
+                <List.Item>kvalifikasjons-/kompetansetillegg</List.Item>
+            </List>
+            <BodyLong>
                 Uregelmessige tillegg knyttet til stillingen eller yrket, arbeidsmengde, arbeidstid eller arbeidssted,
                 og som ikke gis regelmessig. Gjelder tillegg som:
-            </div>
-            <div className={cls.element('lonn-per-mnd-seksjon')}>
-                <ul>
-                    <li>skifttillegg</li>
-                    <li>turnustillegg</li>
-                    <li>offshoretillegg</li>
-                    <li>tillegg for deling av lugar</li>
-                    <li>tillegg for arbeid på lørdag og søndag</li>
-                    <li>tillegg for arbeid på kveld eller om natten </li>
-                </ul>
-            </div>
-        </LesMerPanel>
+            </BodyLong>
+            <List>
+                <List.Item>skifttillegg</List.Item>
+                <List.Item>turnustillegg</List.Item>
+                <List.Item>offshoretillegg</List.Item>
+                <List.Item>tillegg for deling av lugar</List.Item>
+                <List.Item>tillegg for arbeid på lørdag og søndag</List.Item>
+                <List.Item>tillegg for arbeid på kveld eller om natten</List.Item>
+            </List>
+        </ReadMore>
     );
 };
 export default HvaMenesMedDette;

--- a/src/AvtaleSide/steg/BeregningTilskudd/HvaMenesMedDette.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/HvaMenesMedDette.tsx
@@ -14,7 +14,7 @@ const HvaMenesMedDette: React.FC = () => {
                 er ansatt i en 50 % stilling, skal det legges inn månedslønn i 50 % stilling før skatt.
             </BodyLong>
             <BodyLong spacing>
-                Eventuelle lønnsutgifter som oversiger avtalt tilskuddsbeløp, vil ikke bli refundert.
+                Eventuelle lønnsutgifter som overstiger avtalt tilskuddsbeløp, vil ikke bli refundert.
             </BodyLong>
             <BodyLong>
                 Faste tillegg er knyttet til personlige egenskaper, evner eller ansvar og utbetales regelmessig ved hver


### PR DESCRIPTION
Refaktorer HvaMenesMedDette til å bruke Aksel-komponenter

Erstatter plain HTML-elementer med BodyLong, List og ReadMore.
Deler opp langt avsnitt i kortere, logiske avsnitt.
Fjerner BEMHelper og className-prop fra komponenten.

Før|Etter
:-:|:-:
<img width="658" height="718" alt="image" src="https://github.com/user-attachments/assets/b535d9a5-b912-48f1-871d-baa2cf55a5fa" /> | <img width="604" height="954" alt="image" src="https://github.com/user-attachments/assets/b6adb7c7-81a9-4bec-9433-9f6e7a4138aa" />