### PR TITLE
Kort-versjon av navn for fireårig lønnstilskudd

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -91,7 +91,11 @@ export const tiltakstypeTekst: { [key in TiltaksType]: string } = {
     FIREARIG_LONNSTILSKUDD: 'fireårig lønnstilskudd for unge',
 };
 
-export const tiltakstypeTekstKort: { [key in TiltaksType]: string } = { ...tiltakstypeTekst, VTAO: 'VTA-O' };
+export const tiltakstypeTekstKort: { [key in TiltaksType]: string } = {
+    ...tiltakstypeTekst,
+    VTAO: 'VTA-O',
+    FIREARIG_LONNSTILSKUDD: 'Fireårig lønnstilskudd',
+};
 
 export const avtaleTittel: { [key in TiltaksType]: string } = {
     ARBEIDSTRENING: 'Avtale om arbeidstrening',

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -94,7 +94,7 @@ export const tiltakstypeTekst: { [key in TiltaksType]: string } = {
 export const tiltakstypeTekstKort: { [key in TiltaksType]: string } = {
     ...tiltakstypeTekst,
     VTAO: 'VTA-O',
-    FIREARIG_LONNSTILSKUDD: 'Fireårig lønnstilskudd',
+    FIREARIG_LONNSTILSKUDD: 'fireårig lønnstilskudd',
 };
 
 export const avtaleTittel: { [key in TiltaksType]: string } = {


### PR DESCRIPTION
I tabellvisningene har vi lyst til å ha litt kortere navn for denne tiltakstypen, fordi den fulle teksten ender opp med å spenne over flere linjer.

<table>
<tr><th>Før</th><th>Etter</th></tr>
<tr><td><img width="1184" height="509" alt="Screenshot 2026-05-11 at 13-19-06 Tiltaksoversikt (1 avtale) - NAV" src="https://github.com/user-attachments/assets/a03953b4-7fe9-48b7-a053-92fbfa4d7f68" /></td> 
<td>
<img width="1207" height="511" alt="image" src="https://github.com/user-attachments/assets/f7309b4f-2587-4529-9757-1d5200200927" />
</td></tr></table>