### PR TITLE
chore. utvide frist for mentoravtaler fra Arena

### DIFF
--- a/src/komponenter/Banner/BannerNAVAnsatt.tsx
+++ b/src/komponenter/Banner/BannerNAVAnsatt.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 const TOLV_UKER_I_DAGER = 7 * 12;
-const TIDLIGSTE_DATO_FOR_RYDDING_AV_ARENA_MENTOR = endOfDay(new Date('2026-06-01'));
+const TIDLIGSTE_DATO_FOR_RYDDING_AV_ARENA_MENTOR = endOfDay(new Date('2026-06-15'));
 
 const formaterSlettetidspunkt = (avtale: Avtale) => {
     const { sistEndret, opphav, tiltakstype, gjeldendeInnhold } = avtale;


### PR DESCRIPTION
* Utvide med 14 dager (t.o.m den 15 siden den 14 er en søndag).
* Avtalt med brukerstøtte at denne skal utvides da det fortsatt er avtaler som ikke er inngått og fristen går ut om 3 dager.