### PR TITLE
Hotfix tilskuddsprosent sommerjobb

### DIFF
--- a/src/AvtaleSide/steg/BeregningTilskudd/Lonnstilskuddprosent/Lonnstilskuddprosent.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/Lonnstilskuddprosent/Lonnstilskuddprosent.tsx
@@ -71,6 +71,7 @@ const Lonnstilskuddprosent = (props: Props) => {
                         });
                     }}
                 >
+                    <option value="">- Velg tilskuddsprosent -</option>
                     <option value="50">50&nbsp;%</option>
                     <option value="75">75&nbsp;%</option>
                 </Select>


### PR DESCRIPTION
Når bruker ikke har valgt en tilskuddsprosent enda, defaulter vi til å vise at man har valgt 50%. Det skaper forvirring, vi bør heller indikere at de må velge noe.