### PR TITLE
Feil i statusfelt for mentor-avtaler fra arena

### DIFF
--- a/src/AvtaleSide/AvtaleStatus/VeilederAvtaleStatus.tsx
+++ b/src/AvtaleSide/AvtaleStatus/VeilederAvtaleStatus.tsx
@@ -64,7 +64,7 @@ const getAvtalepartStatus = (avtale: Avtale): AvtalepartStatus => {
     if (isVenterPaMentor) {
         return 'VENTER_PÅ_ARBEIDSGIVER_DELTAKER_OG_MENTOR';
     }
-    if (isArena) {
+    if (isArena && avtale.tiltakstype !== 'MENTOR') {
         return 'VENTER_PÅ_ARBEIDSGIVER_OG_DELTAKER_ARENA';
     }
 

--- a/src/AvtaleSide/steg/GodkjenningSteg/Godkjenning/godkjenningVeileder/GodkjenningVeileder.tsx
+++ b/src/AvtaleSide/steg/GodkjenningSteg/Godkjenning/godkjenningVeileder/GodkjenningVeileder.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { AvtaleContext, useAvtale } from '@/AvtaleProvider';
+import { useAvtale } from '@/AvtaleProvider';
 
 import GodkjennPaVegneAvDeltaker from './GodkjennPaVegneAvDeltaker';
 import GodkjennPaVegneAvFlereParter from './GodkjennPaVegneAvFlereParter';


### PR DESCRIPTION
Når man venter på godkjenning fra arbeidsgiver og deltaker står det i statusteksten at man kan godkjenne på vegne av alle parter, men det stemmer ikke for mentor-tiltakene!

Oppdaterer derfor logikken slik at riktig statustekst vises.