### PR TITLE
Antall timer for mentor kan være 0

### DIFF
--- a/src/AvtaleSide/steg/BeregningTilskudd/MentorAntallTimerPerMnd.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/MentorAntallTimerPerMnd.tsx
@@ -64,7 +64,8 @@ function MentorAntallTimerPerMnd(props: Props) {
                 error={formState.errors.mentorAntallTimerPerMnd?.message}
                 label="Antall timer med mentor per måned"
                 onChange={onChange}
-                type="tel"
+                type="text"
+                inputMode="numeric"
                 description="Arbeidsgiver er pliktig til å kontakte Nav for å få oppdatert avtalen dersom behovet for antall timer avviker fra det som er avtalt."
             />
             {(value ?? 0) > NORMAL_ARBEIDSTID_PER_MND && (

--- a/src/AvtaleSide/steg/BeregningTilskudd/MentorAntallTimerPerMnd.tsx
+++ b/src/AvtaleSide/steg/BeregningTilskudd/MentorAntallTimerPerMnd.tsx
@@ -25,7 +25,7 @@ const schema = z.object({
                 required_error: 'Antall timer er påkrevd',
             })
             .int('Antall timer må være et heltall')
-            .min(1, 'Antall timer må være større enn 0')
+            .min(0, 'Antall timer kan ikke være negativt')
             .max(999, 'Antall timer kan ikke overstige 999 timer'),
     ),
 });


### PR DESCRIPTION
Veiledere bruker av og til dette som en slags "pause-funksjon" i avtalen.

Faglige føringer tilsier altså at det skal være mulig å skrive 0 i feltet, og det må vi innfri!

<img width="675" height="600" alt="Skjermbilde fra 2026-06-24 10-38-14" src="https://github.com/user-attachments/assets/6f230360-f746-4ab9-9d07-28623e916a68" />

<img width="675" height="915" alt="Skjermbilde fra 2026-06-24 10-37-48" src="https://github.com/user-attachments/assets/a88d5eba-1074-4e5c-9a08-db96712b416d" />
