### PR TITLE
fix. gjør RadioBlocks generisk og fiks dobbelkall i onChange

### DIFF
--- a/src/AvtaleSide/steg/StillingSteg/LonnstilskuddFormaal.tsx
+++ b/src/AvtaleSide/steg/StillingSteg/LonnstilskuddFormaal.tsx
@@ -65,9 +65,10 @@ const LonnstilskuddFormaal = (props: Props) => {
             <RadioBlocks
                 legend="Hva er formålet med avtalen?"
                 values={lonnstilskuddFormaalVerdier}
-                selectedValue={verdi}
+                selectedValue={field.value}
                 onChange={onChange}
                 direction="row"
+                error={formState.errors.lonnstilskuddFormaal?.message}
             />
             <VerticalSpacer rem={2} />
         </>

--- a/src/komponenter/radioblocks/radioBlocks.module.less
+++ b/src/komponenter/radioblocks/radioBlocks.module.less
@@ -4,8 +4,9 @@
     background-color: @white;
     border: 1px solid @grayModia;
     border-radius: @border-radius-base;
-    padding: 1rem;
     width: 100%;
+    padding: 0 0 0 1rem;
+    align-items: center;
 
     &:hover:not(.is-disabled) {
         border: 1px solid #0067c5;
@@ -16,6 +17,11 @@
     &::after {
         padding: 2rem 1rem 1rem;
         inset: 0;
+    }
+
+    > label {
+        padding-top: 1rem;
+        padding-bottom: 1rem;
     }
 
     @media (min-width: 768px) {


### PR DESCRIPTION
Refaktorer RadioBlocks til en generisk komponent med typesikker onChange-handler som tar verdien direkte fremfor et event-objekt. Wrapper-div gjør hele kortet klikkbart, mens onChange på radio-input håndterer tastaturnavigasjon. Dobbelt kall forhindres ved å sjekke om klikket stammer fra selve input-elementet.

Oppdaterer Stillingstype, LonnstilskuddFormaal og Relasjoner til ny API, og legger til feilvisning i LonnstilskuddFormaal.