### PR TITLE
refactor. migrer ForlengAvtale til CSS Modules og forbedre feilhåndte…

### DIFF
--- a/src/AvtaleSide/steg/GodkjenningSteg/endringAvAvtaleInnhold/forlengAvtale/ForlengAvtale.tsx
+++ b/src/AvtaleSide/steg/GodkjenningSteg/endringAvAvtaleInnhold/forlengAvtale/ForlengAvtale.tsx
@@ -7,8 +7,7 @@ import { TilskuddsPeriode } from '@/types/avtale';
 import { handterFeil } from '@/utils/apiFeilUtils';
 import { Alert, BodyShort, Label, Link } from '@navikt/ds-react';
 import { useState } from 'react';
-import BEMHelper from '@/utils/bem';
-import './forlengAvtale.less';
+import styles from './forlengAvtale.module.less';
 import DatovelgerForlengOgForkort from '@/komponenter/datovelger/DatovelgerForlengOgForkort';
 import { formaterDato, NORSK_DATO_FORMAT } from '@/utils/datoUtils';
 import { addDays } from 'date-fns';
@@ -16,7 +15,6 @@ import { NotePencilIcon } from '@navikt/aksel-icons';
 
 const ForlengAvtale = () => {
     const { avtale, hentAvtale } = useAvtale();
-    const cls = BEMHelper('forlengAvtale');
 
     // Kan trygt anta at sluttdato er satt ved forlenging av avtale
     const naavaerendeSluttDato = avtale.gjeldendeInnhold.sluttDato!;
@@ -28,19 +26,22 @@ const ForlengAvtale = () => {
     const [tilskuddsperioder, setTilskuddsperioder] = useState<TilskuddsPeriode[]>([]);
 
     const forleng = async (): Promise<void> => {
-        if (sluttDato) {
+        if (sluttDato && !feil) {
             await forlengAvtale(avtale, sluttDato);
             await hentAvtale();
             lukkModal();
         }
     };
     const onDatoChange = async (dato: string | undefined): Promise<void> => {
-        setSluttDato(dato);
-        if (dato) {
+        const harDato = dato && dato !== 'Invalid';
+
+        setSluttDato(harDato ? dato : undefined);
+        setFeil(undefined);
+
+        if (harDato) {
             try {
                 const nyAvtale = await forlengAvtaleDryRun(avtale, dato);
                 setTilskuddsperioder(nyAvtale.tilskuddPeriode);
-                setFeil(undefined);
             } catch (e: any) {
                 handterFeil(e, (feilmelding) => {
                     setFeil(feilmelding);
@@ -87,10 +88,10 @@ const ForlengAvtale = () => {
                 bekreftOnClick={kanForlenges ? forleng : undefined}
                 lukkModal={lukkModal}
             >
-                <div className={cls.className}>
+                <div className={styles.forlengAvtale}>
                     {kanForlenges && (
                         <>
-                            <div className={cls.element('navarende-sluttdato')}>
+                            <div className={styles.navarendeSluttdato}>
                                 <Label>Nåværende sluttdato for avtalen</Label>
                                 <BodyShort size="small">
                                     {formaterDato(naavaerendeSluttDato, NORSK_DATO_FORMAT)}
@@ -101,8 +102,16 @@ const ForlengAvtale = () => {
                                 legend="Velg ny sluttdato for avtalen"
                                 onChangeHåndtereNyDato={onDatoChange}
                                 minDate={formaterDato(addDays(naavaerendeSluttDato, 1).toISOString(), 'yyyy-MM-dd')}
-                                error={feil}
                             />
+                            {feil && (
+                                <>
+                                    <VerticalSpacer rem={1} />
+                                    <Alert variant="warning">
+                                        <strong>Avtalen kan ikke forlenges</strong>
+                                        <p className={styles.feilmeldingParagraf}>{feil}</p>
+                                    </Alert>
+                                </>
+                            )}
                             <VerticalSpacer rem={2} />
                             <SlikVilTilskuddsperioderSeUt
                                 overskrift="Slik vil tilskuddsperiodene se ut etter at avtalen forlenges"

--- a/src/AvtaleSide/steg/GodkjenningSteg/endringAvAvtaleInnhold/forlengAvtale/forlengAvtale.less
+++ b/src/AvtaleSide/steg/GodkjenningSteg/endringAvAvtaleInnhold/forlengAvtale/forlengAvtale.less
@@ -1,6 +1,0 @@
-.forlengAvtale {
-    min-height: 20rem;
-    &__navarende-sluttdato {
-        margin: 0.5rem 0 1rem 0;
-    }
-}

--- a/src/AvtaleSide/steg/GodkjenningSteg/endringAvAvtaleInnhold/forlengAvtale/forlengAvtale.module.less
+++ b/src/AvtaleSide/steg/GodkjenningSteg/endringAvAvtaleInnhold/forlengAvtale/forlengAvtale.module.less
@@ -1,0 +1,12 @@
+.forleng-avtale {
+    min-height: 20rem;
+    max-width: 35rem;
+}
+
+.navarende-sluttdato {
+    margin: 0.5rem 0 1rem 0;
+}
+
+.feilmelding-paragraf {
+    margin-bottom: 0;
+}

--- a/src/types/feilkode.ts
+++ b/src/types/feilkode.ts
@@ -140,7 +140,8 @@ export const Feilmeldinger: { [key in Feilkode]: string } = {
     ENHET_ER_JURIDISK: 'Avtale må registreres på virksomhetens virksomhetsnummer, ikke den juridiske enheten.',
     ENHET_ER_ORGLEDD: 'Avtale må registreres på virksomhetens virksomhetsnummer, ikke organisasjonsleddet.',
     ENHET_FINNES_IKKE: 'Finnes ikke i Enhetsregisteret.',
-    ENHET_ER_SLETTET: 'Enheten er slettet',
+    ENHET_ER_SLETTET:
+        'Virksomheten er ikke lenger aktiv. Dette kan skyldes at den har lagt ned eller blitt omorganisert.',
     IKKE_TILGANG_TIL_DELTAKER: 'Du har ikke tilgang til deltaker',
     ALTINN_FEIL: 'Feil ved oppslag mot altinn',
     GOSYS_FEIL: '',


### PR DESCRIPTION
…ring

- Erstatter global LESS med CSS Modules (forlengAvtale.module.less)
- Fjerner BEMHelper til fordel for direkte CSS Modules-referanser
- Viser feilmelding som Alert-komponent i stedet for inline datepicker-feil
- Hindrer forlenging av avtale dersom det finnes en aktiv feil
- Nullstiller feil ved hver datoendring for bedre brukeropplevelse
- Ignorerer ugyldige datoverdier (Invalid) fra datepickeren
- Forbedrer feilmeldingstekst for ENHET_ER_SLETTET