### PR TITLE
oppdaterer TelefonnummerInput for å kunne lagre utenlandske nummer

### DIFF
--- a/src/komponenter/form/TelefonnummerInput.test.tsx
+++ b/src/komponenter/form/TelefonnummerInput.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+
+import TelefonnummerInput from './TelefonnummerInput';
+
+const renderInput = (settVerdi: (verdi?: string) => void) => {
+    const { container } = render(<TelefonnummerInput label="Mobilnummer" name="deltakerTlf" settVerdi={settVerdi} />);
+    return container.querySelector('input') as HTMLInputElement;
+};
+
+describe('TelefonnummerInput', () => {
+    it('lagrer gyldig norsk nummer uten landkode', () => {
+        const settVerdi = vi.fn();
+        const input = renderInput(settVerdi);
+        fireEvent.change(input, { target: { value: '+4741234567' } });
+        expect(settVerdi).toHaveBeenLastCalledWith('41234567');
+    });
+
+    it('lagrer utenlandske nummer', () => {
+        const settVerdi = vi.fn();
+        const input = renderInput(settVerdi);
+        fireEvent.change(input, { target: { value: '+34636263227' } });
+        expect(settVerdi).toHaveBeenLastCalledWith('+34636263227');
+    });
+
+    it('gir undefined når feltet tømmes slik at påkrevd-validering virker', () => {
+        const settVerdi = vi.fn();
+        const input = renderInput(settVerdi);
+        fireEvent.change(input, { target: { value: '41234567' } });
+        fireEvent.change(input, { target: { value: '' } });
+        expect(settVerdi).toHaveBeenLastCalledWith(undefined);
+    });
+});

--- a/src/komponenter/form/TelefonnummerInput.test.tsx
+++ b/src/komponenter/form/TelefonnummerInput.test.tsx
@@ -9,7 +9,7 @@ const renderInput = (settVerdi: (verdi?: string) => void) => {
 };
 
 describe('TelefonnummerInput', () => {
-    it('lagrer gyldig norsk nummer uten landkode', () => {
+    it('lagrer gyldig norsk nummer og fjerner +47-prefiks', () => {
         const settVerdi = vi.fn();
         const input = renderInput(settVerdi);
         fireEvent.change(input, { target: { value: '+4741234567' } });

--- a/src/komponenter/form/TelefonnummerInput.tsx
+++ b/src/komponenter/form/TelefonnummerInput.tsx
@@ -4,7 +4,7 @@ import * as z from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useController, useForm } from 'react-hook-form';
 
-import { formaterNorskeTelefonnummer, NORSK_TELEFONNUMMER_REGEX, parseNorskeTelefonnummer } from '@/utils';
+import { erGyldigTelefonnummer, formaterNorskeTelefonnummer, parseNorskeTelefonnummer } from '@/utils';
 
 export interface Props extends TextFieldProps {
     name: string;
@@ -21,7 +21,7 @@ const schema = (name: string, label: string) =>
                     invalid_type_error: `${label} er ugyldig`,
                     required_error: `${label} er påkrevd`,
                 })
-                .regex(NORSK_TELEFONNUMMER_REGEX, `${label} er ugyldig`),
+                .refine(erGyldigTelefonnummer, `${label} er ugyldig`),
         ),
     });
 

--- a/src/utils/tlfUtils.test.ts
+++ b/src/utils/tlfUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+    erGyldigTelefonnummer,
     formaterNorskeTelefonnummer,
     NORSK_MOBILNUMMER_REGEX,
     NORSK_TELEFONNUMMER_REGEX,
@@ -70,6 +71,72 @@ describe('NORSK_MOBILNUMMER_REGEX', () => {
     });
 });
 
+describe('erGyldigTelefonnummer', () => {
+    it('godtar norsk 8-sifret nummer uten landkode', () => {
+        expect(erGyldigTelefonnummer('21234567')).toBe(true);
+    });
+
+    it('godtar norsk mobilnummer uten landkode', () => {
+        expect(erGyldigTelefonnummer('41234567')).toBe(true);
+    });
+
+    it('godtar norsk nummer med mellomrom', () => {
+        expect(erGyldigTelefonnummer('412 34 567')).toBe(true);
+    });
+
+    it('godtar norsk nummer med +47', () => {
+        expect(erGyldigTelefonnummer('+4741234567')).toBe(true);
+    });
+
+    it('godtar norsk nummer med 0047', () => {
+        expect(erGyldigTelefonnummer('004741234567')).toBe(true);
+    });
+
+    it('avviser norsk nummer med feil lengde', () => {
+        expect(erGyldigTelefonnummer('4123456')).toBe(false);
+    });
+
+    it('avviser norsk nummer med for mange siffer', () => {
+        expect(erGyldigTelefonnummer('412345678')).toBe(false);
+    });
+
+    it('avviser norsk nummer med for mange siffer selv med +47', () => {
+        expect(erGyldigTelefonnummer('+47412345678')).toBe(false);
+    });
+
+    it('avviser norsk nummer som starter med 0', () => {
+        expect(erGyldigTelefonnummer('01234567')).toBe(false);
+    });
+
+    it('godtar utenlandsk nummer med +', () => {
+        expect(erGyldigTelefonnummer('+34636263227')).toBe(true);
+    });
+
+    it('godtar utenlandsk nummer med 00', () => {
+        expect(erGyldigTelefonnummer('004915123456789')).toBe(true);
+    });
+
+    it('avviser utenlandsk nummer uten landkodeprefiks', () => {
+        expect(erGyldigTelefonnummer('34636263227')).toBe(false);
+    });
+
+    it('avviser nummer med spesialtegn', () => {
+        expect(erGyldigTelefonnummer('+34 636!')).toBe(false);
+    });
+
+    it('avviser for langt nummer', () => {
+        expect(erGyldigTelefonnummer('+1234567890123456')).toBe(false);
+    });
+
+    it('avviser tom streng', () => {
+        expect(erGyldigTelefonnummer('')).toBe(false);
+    });
+
+    it('avviser undefined', () => {
+        expect(erGyldigTelefonnummer(undefined)).toBe(false);
+    });
+});
+
 describe('parseNorskeTelefonnummer', () => {
     it('returnerer undefined for undefined', () => {
         expect(parseNorskeTelefonnummer(undefined)).toBeUndefined();
@@ -97,6 +164,14 @@ describe('parseNorskeTelefonnummer', () => {
 
     it('returnerer ugyldig nummer uendret', () => {
         expect(parseNorskeTelefonnummer('abc')).toBe('abc');
+    });
+
+    it('beholder vilkårlig streng med mellomrom uendret', () => {
+        expect(parseNorskeTelefonnummer('abc def')).toBe('abc def');
+    });
+
+    it('beholder utenlandsk nummer uendret', () => {
+        expect(parseNorskeTelefonnummer('+34 636 263 227')).toBe('+34 636 263 227');
     });
 
     it('håndterer number-type som input', () => {

--- a/src/utils/tlfUtils.test.ts
+++ b/src/utils/tlfUtils.test.ts
@@ -166,12 +166,12 @@ describe('parseNorskeTelefonnummer', () => {
         expect(parseNorskeTelefonnummer('abc')).toBe('abc');
     });
 
-    it('beholder vilkårlig streng med mellomrom uendret', () => {
-        expect(parseNorskeTelefonnummer('abc def')).toBe('abc def');
+    it('fjerner mellomrom fra vilkårlig streng', () => {
+        expect(parseNorskeTelefonnummer('abc def')).toBe('abcdef');
     });
 
-    it('beholder utenlandsk nummer uendret', () => {
-        expect(parseNorskeTelefonnummer('+34 636 263 227')).toBe('+34 636 263 227');
+    it('fjerner mellomrom fra utenlandsk nummer men beholder landkode', () => {
+        expect(parseNorskeTelefonnummer('+34 636 263 227')).toBe('+34636263227');
     });
 
     it('håndterer number-type som input', () => {

--- a/src/utils/tlfUtils.ts
+++ b/src/utils/tlfUtils.ts
@@ -23,7 +23,7 @@ export const erGyldigTelefonnummer = (value: unknown): boolean => {
 export const parseNorskeTelefonnummer = (value: unknown): string | undefined => {
     if ((typeof value === 'string' || typeof value === 'number') && value !== '') {
         const tlf = String(value).replace(/\s/g, '');
-        return NORSK_TELEFONNUMMER_REGEX.test(tlf) ? tlf.replace(/^(\+47|0047)/, '') : String(value);
+        return NORSK_TELEFONNUMMER_REGEX.test(tlf) ? tlf.replace(/^(\+47|0047)/, '') : tlf;
     }
     return undefined;
 };

--- a/src/utils/tlfUtils.ts
+++ b/src/utils/tlfUtils.ts
@@ -1,5 +1,24 @@
 export const NORSK_TELEFONNUMMER_REGEX = /^((\+|00)47)?[1-9]\d{7}$/;
 export const NORSK_MOBILNUMMER_REGEX = /^((\+|00)47)?(4|9)\d{7}$/;
+// Utenlandske nummer: +/00-prefiks påkrevd og etterfulgt av 7–15 siffer.
+export const UTENLANDSK_TELEFONNUMMER_REGEX = /^(\+|00)[1-9]\d{6,14}$/;
+
+const harLandkodePrefiks = (tlf: string): boolean => /^(\+|00)/.test(tlf);
+const harNorskLandkode = (tlf: string): boolean => /^(\+|00)47/.test(tlf);
+
+export const erGyldigTelefonnummer = (value: unknown): boolean => {
+    if (typeof value !== 'string' && typeof value !== 'number') {
+        return false;
+    }
+    const tlf = String(value).replace(/\s/g, '');
+    if (tlf === '') {
+        return false;
+    }
+    if (!harLandkodePrefiks(tlf) || harNorskLandkode(tlf)) {
+        return NORSK_TELEFONNUMMER_REGEX.test(tlf);
+    }
+    return UTENLANDSK_TELEFONNUMMER_REGEX.test(tlf);
+};
 
 export const parseNorskeTelefonnummer = (value: unknown): string | undefined => {
     if ((typeof value === 'string' || typeof value === 'number') && value !== '') {


### PR DESCRIPTION
 Retter endring fra #1530 der utenlandske nummer ikke kunne lagres, som blokkerte avtaleopprettelse for EØS-brukere.